### PR TITLE
Added conditional support for Simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.bundle/
+/coverage/
 /doc/
 /log/*.log
 /pkg/

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,9 @@
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts 'Required SimpleCov'
+end
+
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 


### PR DESCRIPTION
## What?

I've added support for SimpleCov. It can be enabled with the `COVERAGE` environment variable.

## Why?

We want to be able to assess test code coverage, but we don't always want it to run as it has an overhead. This is our standard approach to adding SimpleCov.

## How?

If the `COVERAGE` environment variable is set then SimpleCov is included at the top of `test_helper.rb`.

## Testing?

This has been shown to work.

## Anything Else?

No