### PR TITLE
Updated generic table to be plain non-branded one

### DIFF
--- a/lib/design_system/builders/generic/base.rb
+++ b/lib/design_system/builders/generic/base.rb
@@ -12,11 +12,6 @@ module DesignSystem
         def brand
           self.class.name.split('::')[2].underscore
         end
-
-        # This method is for table component to identify if cell is numeric type
-        def cell_numeric?(cell)
-          cell[:options][:type] == 'numeric'
-        end
       end
     end
   end

--- a/lib/design_system/builders/generic/table.rb
+++ b/lib/design_system/builders/generic/table.rb
@@ -55,6 +55,11 @@ module DesignSystem
             end
           end
         end
+
+        # This method is for table component to identify if cell is numeric type
+        def cell_numeric?(cell)
+          cell[:options][:type] == 'numeric'
+        end
       end
     end
   end


### PR DESCRIPTION
## What?

This is to render plain table html in generic table class. 

## Why?

Generic classes (where applicable) will hold code to render plain html components and not with any specific classes as per brands. 

## How?

I have moved branded class style table code to govuk table class and added plain table html code to generic table class.
