### PR TITLE
Moving will_paginate to be spec dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ gem 'dartsass-rails', '~> 0.5'
 gem 'ndr_dev_support', '~> 7.2'
 gem 'sqlite3', '~> 1.3'
 
-gem 'will_paginate', '~> 3.1', '>= 3.1.6'
-
 group :development, :test do
   gem 'cypress-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     design_system (0.1.0)
       rails (>= 7.0.8.1)
+      will_paginate (~> 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -348,7 +349,6 @@ DEPENDENCIES
   puma
   sprockets-rails
   sqlite3 (~> 1.3)
-  will_paginate (~> 3.1, >= 3.1.6)
 
 BUNDLED WITH
    2.5.9

--- a/design_system.gemspec
+++ b/design_system.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'rails', '>= 7.0.8.1'
+  spec.add_dependency 'will_paginate', '~> 3.3'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## What?

Will_paginate gem has been added as spec dependency and removed from Gemfile.

## Why?

This ensures that hosts application need not to install will_paginate separately while adopting design_system.

## How?

Have removed it from Gemfile and moved it to gemspec dependencies.

## Testing?

Have tested on front end via dummy application , and also on hosts applications ->  api_upload_portal , rails_data_platform and pagination works fine everywhere. Also tests are all passing.
