### PR TITLE
Using local stimulus-loading.js

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,3 +1,4 @@
 pin '@stimulus-components/timeago', to: '/design_system/static/stimulus-3.2.2/@stimulus-components--timeago.js'
+pin 'ds-stimulus-loading', to: '/design_system/static/stimulus-3.2.2/stimulus-loading.js'
 pin 'date-fns', to: '/design_system/static/date-fns-4.1.0/index.js'
 pin 'design_system/controllers', to: 'design_system/controllers/index.js'

--- a/test/dummy/app/javascript/controllers/index.js
+++ b/test/dummy/app/javascript/controllers/index.js
@@ -1,6 +1,6 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
 import { application } from "controllers/application"
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+import { eagerLoadControllersFrom } from "ds-stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
 
 import { registerControllers } from "design_system/controllers"


### PR DESCRIPTION
## What?

Using static stimulus-loading file over @hotwired/stimulus-loading.

## Why?

In some scenarios , host application wasn't able to load and use @hotwired/stimulus-loading as its not a npm package . So our design-system can provide locally compiled copy of stimulus-loading.js file.

## How?

We have pinned our static stimulus-loading.js file as 'ds-stimulus-loading' and used it in host app.