### PR TITLE
Added a full_page layout

### DIFF
--- a/app/views/layouts/govuk/full_page.html.erb
+++ b/app/views/layouts/govuk/full_page.html.erb
@@ -1,0 +1,2 @@
+<%# The GOVUK full_page layout is currently no different to application %>
+<%= render template: 'layouts/govuk/application' %>

--- a/app/views/layouts/hdi/application.html.erb
+++ b/app/views/layouts/hdi/application.html.erb
@@ -131,4 +131,4 @@
   </div>
 <% end %>
 
-<%= render template: 'layouts/hdi/base' %>
+<%= render template: 'layouts/hdi/full_page' %>

--- a/app/views/layouts/hdi/full_page.html.erb
+++ b/app/views/layouts/hdi/full_page.html.erb
@@ -30,6 +30,6 @@
     <%= yield :head %>
   </head>
   <body class="h-full" data-ds-brand="<%= brand %>" data-ds-layout="<%= @design_system_layout %>">
-    <%= yield :body %>
+    <%= content_for?(:body) ? yield(:body) : yield %>
   </body>
 </html>

--- a/app/views/layouts/hdi/left_panel.html.erb
+++ b/app/views/layouts/hdi/left_panel.html.erb
@@ -26,4 +26,4 @@
   </div>
 <% end %>
 
-<%= render template: 'layouts/hdi/base' %>
+<%= render template: 'layouts/hdi/full_page' %>

--- a/app/views/layouts/ndrsuk/full_page.html.erb
+++ b/app/views/layouts/ndrsuk/full_page.html.erb
@@ -1,0 +1,2 @@
+<%# The NDRS full_page layout is currently no different to application %>
+<%= render template: 'layouts/ndrsuk/application' %>

--- a/app/views/layouts/nhsuk/full_page.html.erb
+++ b/app/views/layouts/nhsuk/full_page.html.erb
@@ -1,0 +1,2 @@
+<%# The NHS full_page layout is currently no different to application %>
+<%= render template: 'layouts/nhsuk/application' %>

--- a/test/dummy/app/views/layouts/full_page.html.erb
+++ b/test/dummy/app/views/layouts/full_page.html.erb
@@ -1,0 +1,1 @@
+<%= render template: 'layouts/application', locals: { ds_layout: 'full_page' } %>


### PR DESCRIPTION
## What?

I've added a full_page layout.

## Why?

We need a layout which provides us with the normal HTML head, but gives us an empty body.

## How?

The HDI `base` layout has been renamed and modified to allow it to work as a directly referenced layout. GOVUK, NHS and NDRS brands all use the normal application layout (for now).

## Testing?

I've tested this in the dummy app.

## Anything Else?

GOVUK, NHS and NDRS brands should update their full_page layouts at a future date if there is a use case.