### PR TITLE
Fix alignment issue

### DIFF
--- a/lib/design_system/builders/hdi/table.rb
+++ b/lib/design_system/builders/hdi/table.rb
@@ -51,7 +51,7 @@ module DesignSystem
         end
 
         def render_row(row)
-          content_tag(:tr, class: 'whitespace-nowarp border-b border-gray-300 py-2') do
+          content_tag(:tr, class: 'border-b border-gray-300 py-2') do
             row.each_with_object(ActiveSupport::SafeBuffer.new).with_index do |(cell, buffer), index|
               buffer.concat(render_data_cell(cell, index))
             end
@@ -64,7 +64,7 @@ module DesignSystem
             header_text = @table.columns[index][:content]
 
             safe_buffer.concat(content_tag(:span, header_text, class: 'font-semibold text-gray-700 sm:hidden'))
-            safe_buffer.concat(cell[:content].to_s)
+            safe_buffer.concat(content_tag(:span, cell[:content], class: 'sm:text-left text-right'))
 
             safe_buffer
           end

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -46,7 +46,7 @@ ds_table(data: { test: 'table' }) do |table|
     row.add_cell('Ibuprofen')
     row.add_cell('2 pills')
   end
-  table.add_row 'John Doe', 25, 'Ibuprofen', '2 pills'
+  table.add_row 'John Doe', 25, 'Continuous combined hormone replacement therapy (HRT) tablets, capsules and patches', '2 pills'
   table.add_row 'John Doe', 40, 'Ibuprofen', '2 pills'
   table.add_row 'John Doe', 6, 'Ibuprofen', '1 pill'
 end


### PR DESCRIPTION
## What?

Fix HDI table alignment issue when a cell contains multiple lines of content.

## Why?

Previously, `flex` tag would separate cell content if they are split by `<br>` thus looks bad

## How?

Aligning everything to the right for small screens

## Testing?

All tests passed

## Screenshots (optional)

No

## Anything Else?

No
