### PR TITLE
Bumped to v0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    design_system (0.2.0)
+    design_system (0.3.0)
       rails (>= 7.0.8.1)
       stimulus-rails (~> 1.3)
       will_paginate (~> 3.3)

--- a/lib/design_system/version.rb
+++ b/lib/design_system/version.rb
@@ -1,3 +1,3 @@
 module DesignSystem
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end


### PR DESCRIPTION
## What?

I've bumped the design system to v0.3.0.

## Why?

This change makes it easier to deploy the HDI portal.

## How?

I've changed the version constant and done a bundle install.

## Testing?

The tests pass.

## Anything Else?

No