### PR TITLE
Feature/re-register-heroicons into Feature/hdi-frontend-1.0.0

### DIFF
--- a/lib/design_system/engine.rb
+++ b/lib/design_system/engine.rb
@@ -23,6 +23,7 @@ module DesignSystem
         urls: [
           '/design_system/static/date-fns-4.1.0',
           '/design_system/static/govuk-frontend-5.9.0',
+          '/design_system/static/heroicons-2.1.5',
           '/design_system/static/hdi-frontend-0.10.0',
           '/design_system/static/ndrsuk-frontend-9.3.0',
           '/design_system/static/nhsuk-frontend-9.3.0',


### PR DESCRIPTION
## What?

Put heroicons back into `engine.rb`

## Why?

I previously removed the Heroicons path in preparation for moving the icons into `hdi-frontend`, but didn’t complete the move - only updated the path in `engine.rb`. We may still merge it into `hdi-frontend` later, but for now, let’s restore the original line so things work correctly.

## How?

Re-registering heroicons assets in the engine

## Testing?

n/a

## Screenshots (optional)

n/a

## Anything Else?

n/a