### PR TITLE
Fixes to allow form_with model a symbol and multi line hints

### DIFF
--- a/lib/design_system/form_builders/govuk.rb
+++ b/lib/design_system/form_builders/govuk.rb
@@ -9,6 +9,7 @@ module DesignSystem
       include GOVUKDesignSystemFormBuilder::Builder
 
       def initialize(object_name, object, template, options)
+        object_name = object_name.to_s if object_name.is_a?(Symbol)
         super
 
         config.brand = self.class.brand

--- a/lib/design_system/form_builders/nhsuk.rb
+++ b/lib/design_system/form_builders/nhsuk.rb
@@ -33,6 +33,7 @@ module DesignSystem
         button_options = {
           type: 'button',
           class: "#{@brand}-button #{@brand}-button--secondary",
+          style: 'padding: 8px 10px 7px !important',
           aria: { label: 'Show password' },
           data: {
             'module' => "#{@brand}-button",
@@ -48,7 +49,7 @@ module DesignSystem
       def optional_hint(method, hint)
         return nil if hint.nil?
 
-        content_tag(:p, hint, id: field_id("#{method}-hint"), class: "#{@brand}-hint")
+        content_tag(:div, hint, id: field_id("#{method}-hint"), class: "#{@brand}-hint")
       end
     end
   end


### PR DESCRIPTION
## What?

Fixes to allow form_with model a symbol and multi line hints.
Also style has been added around show password button to make its size consistent with text field as discussed earlier.

## Why?

These changes will allow form_with(model: resource) of devise where resource is :user and also multi line hints as needed for password field. 

## How?

Have added in form builder base class to see if model object is a symbol then call a .to_s before calling super.
Changed content_tag(:p) to content_tag(:div) so as to manage both single/multi hints

## Testing?

These changes are being tested by submission portal where screens are getting loaded as expected.

## Screenshots (optional)
Multi line hints- 
<img width="409" alt="Screenshot 2025-04-25 at 10 58 42" src="https://github.com/user-attachments/assets/9665aa44-441b-4a3b-aa7d-170fffff72cf" />


Form gets loaded for devise session new - 

    <%= form_with(model: resource, scope: resource_name, url: session_path(resource_name)

<img width="735" alt="Screenshot 2025-04-25 at 10 57 03" src="https://github.com/user-attachments/assets/201f2274-1499-476f-b42c-e8e7e78993f2" />

Show Password button sizing - 
<img width="660" alt="Screenshot 2025-04-25 at 11 05 44" src="https://github.com/user-attachments/assets/f170fe23-a9e4-42e4-9878-c39811bfb517" />
