### PR TITLE
Bump ds to 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    design_system (0.3.0)
+    design_system (0.4.0)
       govuk_design_system_formbuilder (~> 5.6.0)
       rails (>= 7.0.8.1)
       stimulus-rails (~> 1.3)

--- a/lib/design_system/version.rb
+++ b/lib/design_system/version.rb
@@ -1,3 +1,3 @@
 module DesignSystem
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
## What?

Bump design-system to v0.4.0

## Why?

To reflect the import of HDI styles

## How?

* Update VERSION in `version.rb`
* Run `bundle install` to apply the change

## Testing?

All passed

## Screenshots (optional)

n/a

## Anything Else?

No