### PR TITLE
Added ds_callout

### DIFF
--- a/app/helpers/design_system_helper.rb
+++ b/app/helpers/design_system_helper.rb
@@ -108,4 +108,8 @@ module DesignSystemHelper
   def ds_panel(title, body)
     DesignSystem::Registry.builder(brand, 'panel', self).render_panel(title, body)
   end
+
+  def ds_callout(label, body)
+    DesignSystem::Registry.builder(brand, 'callout', self).render_callout(label, body)
+  end
 end

--- a/lib/design_system/builders/generic/callout.rb
+++ b/lib/design_system/builders/generic/callout.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Builders
+    module Generic
+      # This generates html for rendering warning callout to help users identify and understand warning content on the page, even if they do not read the whole page.
+      class Callout < Base
+        def render_callout(label, body)
+          safe_buffer = ActiveSupport::SafeBuffer.new
+          content_tag(:div, class: "#{brand}-warning-callout") do
+            safe_buffer.concat(render_label(label))
+            safe_buffer.concat(content_tag(:p, body))
+          end
+        end
+
+        private
+
+        def render_label(label)
+          content_tag(:h3, class: "#{brand}-warning-callout__label") do
+            content_tag(:span, role: 'text') do
+              content_tag(:span, 'Important: ', class: "#{brand}-u-visually-hidden") + label
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/design_system/builders/govuk/callout.rb
+++ b/lib/design_system/builders/govuk/callout.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Builders
+    module Govuk
+      # This generates html for rendering warning callout for Govuk
+      class Callout < ::DesignSystem::Builders::Generic::Callout
+        def render_callout(label, body)
+          safe_buffer = ActiveSupport::SafeBuffer.new
+          content_tag(:div, class: "#{brand}-warning-text") do
+            safe_buffer.concat(content_tag(:span, '!', class: "#{brand}-warning-text__icon", 'aria-hidden': 'true'))
+            safe_buffer.concat(render_body(label, body))
+          end
+        end
+
+        private
+
+        def render_body(label, body)
+          content_tag(:strong, class: "#{brand}-warning-text__text") do
+            content_tag(:span, 'Warning', class: "#{brand}-visually-hidden") + label + ' ' + body
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/design_system/builders/hdi/callout.rb
+++ b/lib/design_system/builders/hdi/callout.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Builders
+    module Hdi
+      # This generates html for rendering callout for HDI
+      class Callout < ::DesignSystem::Builders::Generic::Callout
+        private
+
+        def render_label(label)
+          content_tag(:h3, class: "#{brand}-warning-callout__label") do
+            content_tag(:span, role: 'text') do
+              content_tag(:span, 'Important: ', class: "#{brand}-visually-hidden") + label
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/design_system/builders/ndrsuk/callout.rb
+++ b/lib/design_system/builders/ndrsuk/callout.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Builders
+    # This generates html for rendering callout for Ndrsuk
+    module Ndrsuk
+      class Callout < ::DesignSystem::Builders::Generic::Callout
+      end
+    end
+  end
+end

--- a/lib/design_system/builders/nhsuk/callout.rb
+++ b/lib/design_system/builders/nhsuk/callout.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Builders
+    # This generates html for rendering callout for Nhsuk
+    module Nhsuk
+      class Callout < ::DesignSystem::Builders::Generic::Callout
+      end
+    end
+  end
+end

--- a/lib/design_system/generic.rb
+++ b/lib/design_system/generic.rb
@@ -4,6 +4,7 @@
 
 require_relative 'builders/concerns/brand_derivable'
 require_relative 'builders/generic/button'
+require_relative 'builders/generic/callout'
 require_relative 'builders/generic/fixed_elements'
 require_relative 'builders/generic/heading'
 require_relative 'builders/generic/link'

--- a/lib/design_system/govuk.rb
+++ b/lib/design_system/govuk.rb
@@ -3,6 +3,7 @@
 # This is the GOV.UK adapter for the design system
 
 require_relative 'builders/govuk/button'
+require_relative 'builders/govuk/callout'
 require_relative 'builders/govuk/fixed_elements'
 require_relative 'builders/govuk/heading'
 require_relative 'builders/govuk/link'

--- a/lib/design_system/hdi.rb
+++ b/lib/design_system/hdi.rb
@@ -3,6 +3,7 @@
 # This is the HDI branded adapter for the design system
 
 require_relative 'builders/hdi/button'
+require_relative 'builders/hdi/callout'
 require_relative 'builders/hdi/fixed_elements'
 require_relative 'builders/hdi/heading'
 require_relative 'builders/hdi/link'

--- a/lib/design_system/ndrsuk.rb
+++ b/lib/design_system/ndrsuk.rb
@@ -3,6 +3,7 @@ require_relative 'nhsuk'
 # This is the NDRS branding adapter for the design system
 
 require_relative 'builders/ndrsuk/button'
+require_relative 'builders/ndrsuk/callout'
 require_relative 'builders/ndrsuk/fixed_elements'
 require_relative 'builders/ndrsuk/heading'
 require_relative 'builders/ndrsuk/link'

--- a/lib/design_system/nhsuk.rb
+++ b/lib/design_system/nhsuk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'builders/nhsuk/button'
+require_relative 'builders/nhsuk/callout'
 require_relative 'builders/nhsuk/fixed_elements'
 require_relative 'builders/nhsuk/heading'
 require_relative 'builders/nhsuk/link'

--- a/public/design_system/static/hdi-frontend-0.11.0/hdi.scss
+++ b/public/design_system/static/hdi-frontend-0.11.0/hdi.scss
@@ -5112,6 +5112,33 @@
     flex: 1;
   }
 }
+.hdi-warning-callout {
+  display: block;
+  max-width: var(--container-sm);
+  border-radius: var(--radius-lg);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+  }
+  padding: calc(var(--spacing) * 6);
+  color: var(--color-neutral);
+  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  background-color: var(--color-warning-light);
+}
+.hdi-warning-callout__label {
+  margin-bottom: calc(var(--spacing) * 2);
+  font-size: var(--text-2xl);
+  line-height: var(--tw-leading, var(--text-2xl--line-height));
+  --tw-font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-bold);
+  --tw-tracking: var(--tracking-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-neutral);
+  background-color: var(--color-warning-label-light);
+}
 .hdi-button-group {
   margin-bottom: calc(var(--spacing) * 6);
   display: flex;
@@ -5732,6 +5759,7 @@ h1.hdi-heading-xl + .hdi-button, h2.hdi-heading-l + .hdi-button, h3.hdi-heading-
     --color-error-light: rgb(254 242 242);
     --color-error-content-light: rgb(189 39 51);
     --color-error-icon-light: rgb(189 39 51);
+    --color-warning-light: rgb(255, 249, 196);
   }
 }
 @layer base {
@@ -5772,6 +5800,7 @@ h1.hdi-heading-xl + .hdi-button, h2.hdi-heading-l + .hdi-button, h3.hdi-heading-
       --color-error-light: rgb(130 24 26);
       --color-error-content-light: #ffffff;
       --color-error-icon-light: rgb(255 226 226);
+      --color-warning-light: rgb(255, 249, 196);
     }
   }
 }
@@ -5812,6 +5841,7 @@ h1.hdi-heading-xl + .hdi-button, h2.hdi-heading-l + .hdi-button, h3.hdi-heading-
     --color-error-light: rgb(130 24 26);
     --color-error-content-light: #ffffff;
     --color-error-icon-light: rgb(255 226 226);
+    --color-warning-light: rgb(255, 249, 196);
   }
 }
 @layer base {

--- a/test/builders/govuk/callout_test.rb
+++ b/test/builders/govuk/callout_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DesignSystem
+  module Builders
+    module Govuk
+      # This tests the govuk callout builder
+      class CalloutTest < ActionView::TestCase
+        include DesignSystemHelper
+
+        setup do
+          @brand = 'govuk'
+          @controller.stubs(:brand).returns(@brand)
+        end
+
+        test 'rendering govuk callout' do
+          @output_buffer = ds_callout('Important Notice:', 'This is important!')
+
+          assert_select 'div.govuk-warning-text' do
+            assert_select 'span.govuk-warning-text__icon', '!'
+            assert_select 'strong.govuk-warning-text__text', /Important Notice: This is important!/
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/builders/hdi/callout_test.rb
+++ b/test/builders/hdi/callout_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DesignSystem
+  module Builders
+    module Hdi
+      # This tests the hdi callout builder
+      class CalloutTest < ActionView::TestCase
+        include DesignSystemHelper
+
+        setup do
+          @brand = 'hdi'
+          @controller.stubs(:brand).returns(@brand)
+        end
+
+        test 'rendering hdi callout' do
+          @output_buffer = ds_callout('Important Notice:', 'This is important!')
+
+          assert_select 'div.hdi-warning-callout' do
+            assert_select 'h3.hdi-warning-callout__label', text: /Important Notice:/ do
+              assert_select 'span.hdi-visually-hidden', text: 'Important:'
+            end
+            assert_select 'p', 'This is important!'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/builders/nhsuk/callout_test.rb
+++ b/test/builders/nhsuk/callout_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DesignSystem
+  module Builders
+    module Nhsuk
+      # This tests the nhsuk callout builder
+      class CalloutTest < ActionView::TestCase
+        include DesignSystemHelper
+
+        setup do
+          @brand = 'nhsuk'
+          @controller.stubs(:brand).returns(@brand)
+        end
+
+        test 'rendering nhsuk callout' do
+          @output_buffer = ds_callout('Important Notice:', 'This is important!')
+
+          assert_select 'div.nhsuk-warning-callout' do
+            assert_select 'h3.nhsuk-warning-callout__label', text: /Important Notice:/ do
+              assert_select 'span.nhsuk-u-visually-hidden', text: 'Important:'
+            end
+            assert_select 'p', 'This is important!'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -125,3 +125,8 @@ end
 <%= ds_heading 'Panel' %>
 <%= ds_panel('Application confirmed', 'We have sent you a confirmation email') %>
 
+<br/>
+<%= ds_heading 'Warning Callout' %>
+<%= ds_callout('School Message:', 'Half term break is over !!') %>
+
+


### PR DESCRIPTION
## What?

I've added [warning callout](https://service-manual.nhs.uk/design-system/components/warning-callout) component  for design system. An equivalent in govuk is considered [warning text](https://design-system.service.gov.uk/components/warning-text/) component .

## Why?

Submission portal needed a warning callout display so added in design system so as it can be used for rendering a warning callout.

## How?

This includes adding a helper method and builder class callout for each brand .

## Testing?

Tests have been added.

## Screenshots (optional)
NHS/NDRS
<img width="942" alt="Screenshot 2025-06-04 at 13 26 10" src="https://github.com/user-attachments/assets/dcff436b-42f7-4a2a-9be2-cdfbea3cbe1a" />

GOVUK
<img width="455" alt="Screenshot 2025-06-04 at 13 26 34" src="https://github.com/user-attachments/assets/ebd2d69e-ca8a-44ba-abc7-52c9872c7891" />

HDI
<img width="424" alt="Screenshot 2025-06-04 at 13 26 59" src="https://github.com/user-attachments/assets/dbc01cd2-9b59-499c-bc7f-281692982ec3" />


## Anything Else?

For HDI , a [PR](https://github.com/HealthDataInsight/hdi-frontend/pull/67) in hdi-frontend to add required styles have been already done and merged. And updated hdi.css has been imported here.
