### PR TITLE
Option to suppress inline error message added

### DIFF
--- a/config/initializers/govuk_form_builder_overrides.rb
+++ b/config/initializers/govuk_form_builder_overrides.rb
@@ -49,4 +49,50 @@ module GOVUKDesignSystemFormBuilder
       end
     end
   end
+
+  module Traits
+    module Error
+      private
+
+      def error_element
+        # Check if @html_attributes is defined and contains the suppress_error key.
+        # This instance variable is typically set by other traits like Traits::Input or Traits::Field.
+        if instance_variable_defined?(:@html_attributes) &&
+           @html_attributes &&
+           @html_attributes.key?(:suppress_error) &&
+           @html_attributes[:suppress_error]
+          @error_element = NullErrorElement.new(*bound) # Suppress the error message
+        else
+          # The `bound` method (from Elements::Base) provides [@builder, @object_name, @attribute_name].
+          @error_element ||= GOVUKDesignSystemFormBuilder::Elements::ErrorMessage.new(*bound)
+        end
+      end
+    end
+  end
+
+  # Null Object for suppressed error messages
+  class NullErrorElement
+    # Takes the same arguments as the real ErrorMessage constructor for compatibility
+    def initialize(builder, object_name, attribute_name, **_kwargs)
+      # We don't need to store them for this null object
+    end
+
+    def html
+      ActiveSupport::SafeBuffer.new # Renders no HTML
+    end
+
+    def to_s
+      '' # Returns an empty string if the object itself is converted to a string
+    end
+
+    def error_id
+      nil # Important for aria-describedby, indicates no specific error ID
+    end
+
+    private
+
+    def has_errors?
+      false # So it doesn't try to render itself as if it has errors
+    end
+  end
 end

--- a/test/form_builders/concerns/govuk_form_builder_testable.rb
+++ b/test/form_builders/concerns/govuk_form_builder_testable.rb
@@ -1098,5 +1098,40 @@ module GovukFormBuilderTestable
         end
       end
     end
+
+    test 'suppresses inline error when suppress_error is true' do
+      @assistant = Assistant.new
+      assert_not @assistant.valid?
+      assert @assistant.errors[:title].any?, 'Title should have errors'
+
+      @output_buffer = form_with(model: @assistant, builder: @builder, url: '#') do |f|
+        f.ds_text_field(:title, label: { text: 'Title' }, suppress_error: true)
+      end
+
+      # Assert that the inline error message is NOT present
+      assert_select_from(@output_buffer, "p.#{@brand}-error-message", count: 0)
+    end
+
+    test 'shows inline error when suppress_error is false' do
+      @assistant = Assistant.new
+      assert_not @assistant.valid?
+      assert @assistant.errors[:title].any?, 'Title should have errors'
+
+      @output_buffer = form_with(model: @assistant, builder: @builder, url: '#') do |f|
+        f.govuk_text_field(:title, label: { text: 'Title' }, suppress_error: false)
+      end
+
+      # Assert that the inline error message IS present
+      @assistant.errors[:title].first
+      assert_select_from(@output_buffer, "p.#{@brand}-error-message", count: 1)
+    end
+
+    private
+
+    # Helper to use assert_select on a string of HTML output
+    def assert_select_from(html_output, ...)
+      parsed_html = Nokogiri::HTML::DocumentFragment.parse(html_output)
+      assert_select(parsed_html, ...)
+    end
   end
 end


### PR DESCRIPTION
## What?

I've added support to form builder to have an optional field suppress_error which when set to true will suppress inline error message from govuk form builder.

## Why?

For Peugic forms we need our own custom error messages over fields when validation fails and then two error messages were being displayed one from GOVUKDesignSystemFormBuilder and one from custom one. So we needed  flexibility to turn it off.

## How?

We override the error_element returned from https://github.com/x-govuk/govuk-form-builder/blob/main/lib/govuk_design_system_formbuilder/traits/error.rb to return custom null one if in options `suppress_error` is coming as true.

## Testing?

Tests have been added and are passing now

## Screenshots (optional)

Before- 
<img width="625" alt="Screenshot 2025-07-02 at 15 25 41" src="https://github.com/user-attachments/assets/7c55feb4-9a19-4917-8460-856d5b9522a3" />

After - 
<img width="585" alt="Screenshot 2025-07-02 at 15 24 54" src="https://github.com/user-attachments/assets/31aa9b88-a3c9-4736-a325-7c23875fc33e" />

