### PR TITLE
Fix/hidden legend

### DIFF
--- a/config/initializers/govuk_form_builder_overrides.rb
+++ b/config/initializers/govuk_form_builder_overrides.rb
@@ -66,6 +66,7 @@ module GOVUKDesignSystemFormBuilder
 
     class Legend
       using PrefixableArray
+
       private
 
       def classes

--- a/test/form_builders/govuk_test.rb
+++ b/test/form_builders/govuk_test.rb
@@ -176,7 +176,7 @@ module FormBuilders
 
     test 'legend hidden' do
       @output_buffer = form_with(model: assistants(:one), builder: @builder) do |f|
-        f.ds_date_field(:date_of_birth, hint: "Demo for ds_date_field", date_of_birth: true, legend: { text:'Find me', size: nil, hidden: true })
+        f.ds_date_field(:date_of_birth, hint: 'Demo for ds_date_field', date_of_birth: true, legend: { text: 'Find me', size: nil, hidden: true })
       end
 
       assert_select("legend.#{@brand}-fieldset__legend.#{@brand}-visually-hidden", text: 'Find me')

--- a/test/form_builders/hdi_test.rb
+++ b/test/form_builders/hdi_test.rb
@@ -142,7 +142,7 @@ module FormBuilders
 
     test 'legend hidden' do
       @output_buffer = form_with(model: assistants(:one), builder: @builder) do |f|
-        f.ds_date_field(:date_of_birth, hint: "Demo for ds_date_field", date_of_birth: true, legend: { text:'Find me', size: nil, hidden: true })
+        f.ds_date_field(:date_of_birth, hint: 'Demo for ds_date_field', date_of_birth: true, legend: { text: 'Find me', size: nil, hidden: true })
       end
 
       assert_select("legend.#{@brand}-fieldset__legend.#{@brand}-visually-hidden", text: 'Find me')

--- a/test/form_builders/nhsuk_test.rb
+++ b/test/form_builders/nhsuk_test.rb
@@ -99,7 +99,7 @@ module FormBuilders
 
     test 'legend hidden' do
       @output_buffer = form_with(model: assistants(:one), builder: @builder) do |f|
-        f.ds_date_field(:date_of_birth, hint: "Demo for ds_date_field", date_of_birth: true, legend: { text:'Find me', size: nil, hidden: true })
+        f.ds_date_field(:date_of_birth, hint: 'Demo for ds_date_field', date_of_birth: true, legend: { text: 'Find me', size: nil, hidden: true })
       end
 
       assert_select("legend.#{@brand}-fieldset__legend.#{@brand}-u-visually-hidden", text: 'Find me')


### PR DESCRIPTION
## What?

Fix hidden label/legend for NHS and NDRS

## Why?

GOVUK and HDI use `visually-hidden` for hidden class, while NHS and NDRS use `u-visually-hidden`
GOVUKDesignSystemFormBuilder Gem failed at the latter two brands when you want to hide a field label/legend

## How?

I reopened `GOVUKDesignSystemFormBuilder::Label` and `GOVUKDesignSystemFormBuilder::Legend` and overrode the relevant methods to dynamically concat the correct hidden class based on brand name.

## Testing?

Unit tests passed
Dummy app eyeballed

## Screenshots (optional)

N/A

## Anything Else?

No