### PR TITLE
Stop humanising options for checkbox if translation isn't present and tests to compare html from ds elements and rails elements

### DIFF
--- a/lib/design_system/form_builders/govuk.rb
+++ b/lib/design_system/form_builders/govuk.rb
@@ -24,7 +24,7 @@ module DesignSystem
         unchecked_value = false if unchecked_value == '0'
 
         # First try to find a custom translation for this specific value
-        # If no custom translation provided, fall back to the default humanised value
+        # If no custom translation provided, fall back to the default value
         custom_translation = translated_label_for_value(method, value)
         label = if custom_translation.include?('Translation missing')
                   optional_label(value, options)
@@ -400,9 +400,16 @@ module DesignSystem
         # This method is used to translate the label for a given value
         # Example: assign an alternative name for checkbox items
         method_and_value = "#{method}.#{value}"
-        ActionView::Helpers::Tags::Translator.
-          new(object, object_name, method_and_value, scope: 'helpers.options').
-          translate
+        translation = ActionView::Helpers::Tags::Translator.
+                      new(object, object_name, method_and_value, scope: 'helpers.options').
+                      translate
+        # If translation returns the humanized version of the value,
+        # it means no translation was found, so return the original value
+        if translation == value.to_s.humanize
+          value.to_s
+        else
+          translation
+        end
       end
 
       # GOVUKDesignSystemFormBuilder::Base field_id method


### PR DESCRIPTION
## What?

- I've made changes to stop humanising options for checkbox if translation isn't present.
- I've added tests so as we can confirm that html produced by ds_ form helper methods and rails form helper methods are same.

## Why?

- For checkbox options we want translations to supersede but if not present whatever value is present must be shown as label.
- This gives the confidence that ds_ elements are producting the desired html.

## How?

- Translation work in a way that they try to find the translation for an element in the locale file , and if not present returns the value after calling humanize method on it. This isn't a desired behaviour for our application for checkbox options ,so we have stopped the default behaviour of calling humanize on the option labels.
- By adding tests of comparing the html outputs from both form helpers DS and Rails. Nokogiri::HTML is used to parse the output and compare.

## Testing?

Tests have been added and all pass

## Screenshots (optional)

Before
<img width="662" height="141" alt="Screenshot 2025-07-17 at 16 02 40" src="https://github.com/user-attachments/assets/5f0f944d-b95f-4f3d-b750-bf95db6f6fb7" />


After
<img width="690" height="142" alt="Screenshot 2025-07-17 at 16 01 12" src="https://github.com/user-attachments/assets/618d9943-db82-4700-9905-aa4e7c4ea5c7" />
