### PR TITLE
Tab component able to capture block content

### DIFF
--- a/lib/design_system/components/tab.rb
+++ b/lib/design_system/components/tab.rb
@@ -6,12 +6,14 @@ module DesignSystem
     class Tab
       attr_accessor :tabs, :title
 
-      def initialize
+      def initialize(view_context = nil)
+        @view_context = view_context
         @tabs = []
       end
 
-      def add_tab_panel(name, content, id, sel: false)
-        @tabs << [name, content, id, sel]
+      def add_tab_panel(name, content, id = nil, selected: false, &block)
+        content ||= @view_context.capture(&block) if block_given?
+        @tabs << [name, content, id, selected]
       end
     end
   end

--- a/lib/design_system/govuk/builders/tab.rb
+++ b/lib/design_system/govuk/builders/tab.rb
@@ -8,7 +8,7 @@ module DesignSystem
       # This class provides GOVUK Tab.
       class Tab < ::DesignSystem::Generic::Builders::Tab
         def render_tabs
-          @tab = ::DesignSystem::Components::Tab.new
+          @tab = ::DesignSystem::Components::Tab.new(self)
 
           yield @tab
           content_tag(:div, class: "#{brand}-tabs", 'data-module': "#{brand}-tabs") do

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -66,16 +66,15 @@ end
 ds_tab do |tab|
   tab.title = 'Contents'
   #(name, content, id, selected)
-  tab.add_tab_panel('Profile',
-                    ds_table do |table|
-                      table.caption = 'Profile'
-                      table.add_column('Name')
-                      table.add_column('Gender')
-                      table.add_numeric_column('Age')
-                      table.add_row 'Ryan', 'Male', 30
-                    end,
-                    'profile',
-                    sel: true)
+  tab.add_tab_panel('Profile', nil, 'profile',selected: true) do
+	  ds_table do |table|
+		  table.caption = 'Profile'
+		  table.add_column('Name')
+		  table.add_column('Gender')
+		  table.add_numeric_column('Age')
+		  table.add_row 'Ryan', 'Male', 30
+	  end
+  end
   tab.add_tab_panel('Dashboard','this is dashboard' ,'dashboard')
   tab.add_tab_panel('Settings', 'this is settings','settings')
   tab.add_tab_panel('Contacts', 'this is contacts', 'contacts')

--- a/test/govuk/builders/tab_test.rb
+++ b/test/govuk/builders/tab_test.rb
@@ -16,13 +16,26 @@ module DesignSystem
 
         test 'rendering govuk tab' do
           @output_buffer = ds_tab do |tab|
-            tab.add_tab_panel('Test', 'test paragraph', 'test', sel: true)
+            tab.add_tab_panel('Test', 'test paragraph', 'test', selected: true)
             tab.add_tab_panel('Trial', 'trial paragraph', 'trial')
           end
 
           assert_select('ul.govuk-tabs__list li', 2)
           assert_select('a.govuk-tabs__tab', text: 'Test')
           assert_select('div.govuk-tabs__panel', text: 'test paragraph')
+        end
+
+        test 'rendering govuk tab with html' do
+          @output_buffer = ds_tab do |tab|
+            tab.add_tab_panel('Test', nil, 'test', selected: true) do
+              tag.p('a paragraph')
+            end
+            tab.add_tab_panel('Trial', 'trial paragraph', 'trial')
+          end
+
+          assert_select('ul.govuk-tabs__list li', 2)
+          assert_select('a.govuk-tabs__tab', text: 'Test')
+          assert_select('div.govuk-tabs__panel p', text: 'a paragraph')
         end
       end
     end


### PR DESCRIPTION
## What?

I've added support for tab component to be able to capture the content via block as well.

## Why?

These changes resolves #61 .

## How?

By using Rails view_context.capture.

## Testing?

Tests added and pass.

## Screenshots (optional)

Passing table in tab block - 

<img width="821" height="347" alt="Screenshot 2025-08-01 at 18 04 04" src="https://github.com/user-attachments/assets/dcdf2698-fc61-4470-af88-90a8f446818c" />

## Anything Else?
Also as per @timgentry's suggestion renamed 'sel' to 'selected' to make it more clear for user while passing param.
