### PR TITLE
Checkbox label with dot fix

### DIFF
--- a/lib/design_system/govuk/form_builder.rb
+++ b/lib/design_system/govuk/form_builder.rb
@@ -405,7 +405,9 @@ module DesignSystem
                       translate
         # If translation returns the humanized version of the value,
         # it means no translation was found, so return the original value
-        if translation == value.to_s.humanize
+        # Extra condition: if value contains dots and translation is only the last part
+        if translation == value.to_s.humanize ||
+           (value.to_s.include?('.') && translation == value.to_s.split('.').last.humanize)
           value.to_s
         else
           translation

--- a/test/govuk/concerns/govuk_form_builder_testable.rb
+++ b/test/govuk/concerns/govuk_form_builder_testable.rb
@@ -119,6 +119,20 @@ module GovukFormBuilderTestable
       end
     end
 
+    test 'ds_check_box item with dot in value is not incorrectly translated' do
+      value_with_dot = 'Made up dummy values (e.g. see with dot it works)'
+      @output_buffer = ds_form_with(model: DummyModel.new, builder: @builder, url: '/') do |f|
+        f.ds_check_box(:role, {}, value_with_dot)
+      end
+
+      assert_select('form') do
+        assert_select("div.#{@brand}-checkboxes__item") do
+          label = assert_select("label.#{@brand}-label.#{@brand}-checkboxes__label").first
+          assert_equal value_with_dot, label.text.strip
+        end
+      end
+    end
+
     test 'ds_collection_select' do
       @output_buffer = ds_form_with(model: assistants(:one), builder: @builder) do |f|
         f.ds_collection_select(:department_id, Department.all, :id, :title)


### PR DESCRIPTION
## What?

I have fixed the https://github.com/HealthDataInsight/audit_form_generator/issues/88. Checkbox label with dot after not finding translation were being rendered via fallback mechanism and getting shortened.

## Why?

One of the options "Changes to peripancreatic vessels (e.g. stricturing with calibre change and lumen deformity)" is being cropped - it only was rendering "stricturing with calibre change and lumen deformity)".

## How?

I have added the extra consition to compare what translation is being returned and if its not what we expect we rturn back the value without being translated.

## Testing?

Test for the condition is added and it passes now.

## Screenshots (optional)

New (correct)- 
<img width="640" height="67" alt="Screenshot 2025-08-05 at 14 22 55" src="https://github.com/user-attachments/assets/5a08f270-d7b9-486e-8d80-345c5994570c" />

Old (Faulty) -
<img width="736" height="98" alt="Screenshot 2025-08-05 at 14 24 11" src="https://github.com/user-attachments/assets/7ae6ed03-2e88-4768-aad2-a7cd6f055682" />


