### PR TITLE
Fixed NHSUK notice to be an inset text rather warning callout resolves #147

### DIFF
--- a/lib/design_system/nhsuk/builders/notification.rb
+++ b/lib/design_system/nhsuk/builders/notification.rb
@@ -6,13 +6,9 @@ module DesignSystem
       # This class provides Nhsuk notifications html.
       class Notification < ::DesignSystem::Govuk::Builders::Notification
         def render_notice(msg)
-          header = content_tag(:h3, class: "#{brand}-warning-callout__label") do
-            'Important'.html_safe +
-              content_tag(:span, ':', class: "#{brand}-u-visually-hidden")
-          end
           content = content_tag(:p, sanitize(msg, tags: %w[b p br a], attributes: %w[href targ]))
-          content_tag(:div, class: "#{brand}-warning-callout") do
-            header + content
+          content_tag(:div, class: "#{brand}-inset-text") do
+            content_tag(:span, 'Information:', class: "#{brand}-u-visually-hidden") + content
           end
         end
       end

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -1,3 +1,5 @@
+<%= ds_alert("I am an alert")%>
+<%= ds_notice("I am a notice")%>
 <%=
 ds_fixed_elements do |ds|
   ds.breadcrumb 'One', root_path

--- a/test/nhsuk/builders/notification_test.rb
+++ b/test/nhsuk/builders/notification_test.rb
@@ -16,16 +16,16 @@ module DesignSystem
 
         test 'rendering nhsuk notice' do
           @output_buffer = ds_notice('Important Notice')
-          assert_select 'div.nhsuk-warning-callout' do
-            assert_select 'h3.nhsuk-warning-callout__label', 'Important:'
+          assert_select 'div.nhsuk-inset-text' do
+            assert_select 'span', 'Information:'
             assert_select 'p', 'Important Notice'
           end
         end
 
         test 'rendering nhsuk notice with sanitizing content' do
           @output_buffer = ds_notice('<b>Important Notice:<br> check link <a href="/"> here </a></b>')
-          assert_select 'div.nhsuk-warning-callout' do
-            assert_select 'h3.nhsuk-warning-callout__label', 'Important:'
+          assert_select 'div.nhsuk-inset-text' do
+            assert_select 'span', 'Information:'
             assert_select 'p' do
               assert_select 'b', text: 'Important Notice: check link  here' do
                 assert_select 'a', text: 'here'


### PR DESCRIPTION
## What?

I have fixed notices for Nhsuk which resolves  #147 

## Why?

NhsUk notices earlier were using warning callout but rather for notices, its advisable to render them as inset text.

## How?

I have updated the render_notice method for NhsUk notification builder.

## Testing?

Have updated the tests and they pass.

## Screenshots (optional)

<img width="485" height="105" alt="Screenshot 2025-08-07 at 17 13 09" src="https://github.com/user-attachments/assets/10ecc005-2762-4d05-a11e-8d5e441e9450" />
