### PR TITLE
Removed an old engine reference to date-fns. Resolves #43.

### DIFF
--- a/lib/design_system/engine.rb
+++ b/lib/design_system/engine.rb
@@ -17,7 +17,6 @@ module DesignSystem
         ::ActionDispatch::RemoteIp,
         ::Rack::Static,
         urls: [
-          '/design_system/static/date-fns-4.1.0',
           "/design_system/static/design_system-#{DesignSystem::VERSION}",
           '/design_system/static/govuk-frontend-5.11.1',
           '/design_system/static/nhsuk-frontend-9.6.4',


### PR DESCRIPTION
## What?

I've removed an old engine reference to date-fns.

## Why?

date-fns is now pulled in via npm, so the static path no longer exists and is no longer needed.

## How?

I've removed the static path.

## Testing?

Automated tests pass and the page updated when viewed manually.

## Anything Else?

No