### PR TITLE
Fix ds_hidden_field usage in dummy app

### DIFF
--- a/test/dummy/app/views/assistants/_form.html.erb
+++ b/test/dummy/app/views/assistants/_form.html.erb
@@ -15,7 +15,7 @@
     <%= form.ds_date_field :date_of_birth, hint: "Demo for ds_date_field", date_of_birth: true, legend: { size: nil }%>
   <% end %>
 
-  <%= form.ds_hidden_field :desired_filling, value: :pastrami, show_text: "This is a readonly text field", label: { size: 'm', text: 'This is a label for a hidden field' } %>
+  <%= form.ds_hidden_field :title, value: 'You should not see this', show_text: "This is a readonly text field", label: { size: 'm', text: 'This is a label for a hidden field' } %>
 
   <%= form.ds_field_set_tag "Checkboxes" do %>
     <%= form.ds_collection_check_boxes :desired_filling, Assistant::FILLINGS, :id, :title, hint_method: :description, hint: "Demo for ds_collection_check_boxes" %>


### PR DESCRIPTION
## What?

Fix ds_hidden_field usage in dummy app

## Why?

The form submission was not successful due to a mismatched data type

## How?

I replaced desired_filling with title, which is a single-select field

## Testing?

All passed

## Screenshots (optional)

N/A

## Anything Else?

No