### PR TITLE
Bumped govuk_design_system_formbuilder resolves #160

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     design_system (0.7.0)
-      govuk_design_system_formbuilder (~> 5.6.0)
+      govuk_design_system_formbuilder (~> 5.11.0)
       rails (>= 7.0.8.1)
       stimulus-rails (~> 1.3)
       will_paginate (~> 4.0.1)
@@ -142,7 +142,7 @@ GEM
     google-protobuf (3.25.3-arm64-darwin)
     google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
-    govuk_design_system_formbuilder (5.6.0)
+    govuk_design_system_formbuilder (5.11.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)

--- a/design_system.gemspec
+++ b/design_system.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib,public}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'govuk_design_system_formbuilder', '~> 5.6.0'
+  spec.add_dependency 'govuk_design_system_formbuilder', '~> 5.11.0'
   spec.add_dependency 'rails', '>= 7.0.8.1'
   spec.add_dependency 'stimulus-rails', '~> 1.3'
   spec.add_dependency 'will_paginate', '~> 4.0.1'


### PR DESCRIPTION
## What?

I have bumped govuk_design_system_formbuilder gem to latest version 5.11.0.

## Why?

These changes resolve #160 and prep towards releasing DS as gem.

## How?

Updated gem version.

## Testing?

Tests pass

## Screenshots (optional)

N/A