### PR TITLE
Removed duplicate db setup and updated action names

### DIFF
--- a/.github/workflows/wcag2aa.yml
+++ b/.github/workflows/wcag2aa.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
           cache-dependency-path: test/dummy/package-lock.json
 
-      - name: Install dependencies
+      - name: Install JavaScript dependencies
         working-directory: test/dummy
         run: npm install
 
@@ -38,10 +38,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Prepare the database
-        run: bin/rails db:setup
-
-      - name: Install dependencies
+      - name: Install Ruby dependencies
         run: |
           gem install foreman
           bundle install

--- a/.github/workflows/wcag2aaa.yml
+++ b/.github/workflows/wcag2aaa.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
           cache-dependency-path: test/dummy/package-lock.json
 
-      - name: Install dependencies
+      - name: Install JavaScript dependencies
         working-directory: test/dummy
         run: npm install
 
@@ -38,10 +38,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Prepare the database
-        run: bin/rails db:setup
-
-      - name: Install dependencies
+      - name: Install Ruby dependencies
         run: |
           gem install foreman
           bundle install


### PR DESCRIPTION
## What?

I've removed duplicate database setup from the WCAG accessibility GitHub actions.

## Why?

They are duplicated in error.

## How?

I removed the actions prior to JS and Ruby dependency installation and renamed those actions for clarity.

## Testing?

This can only be shown to work once merged.

## Anything Else?

No
