### PR TITLE
Cleaned up require calls with Zeitwerk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Cleaned up require calls with Zeitwerk
+
 ## [0.7.0] - 2025-08-22
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       rails (>= 7.0.8.5)
       stimulus-rails (~> 1.3)
       will_paginate (~> 4.0.1)
+      zeitwerk (~> 2.6)
 
 GEM
   remote: https://rubygems.org/

--- a/app/helpers/design_system_helper.rb
+++ b/app/helpers/design_system_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/registry'
-
 # The helpers for the design system
 module DesignSystemHelper
   include ActionView::Helpers::FormHelper

--- a/design_system.gemspec
+++ b/design_system.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 7.0.8.5'
   spec.add_dependency 'stimulus-rails', '~> 1.3'
   spec.add_dependency 'will_paginate', '~> 4.0.1'
+  spec.add_dependency 'zeitwerk', '~> 2.6'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/design_system.rb
+++ b/lib/design_system.rb
@@ -1,3 +1,8 @@
+require 'zeitwerk'
+
+loader = Zeitwerk::Loader.for_gem
+loader.setup
+
 require 'design_system/version'
 require 'design_system/engine'
 

--- a/lib/design_system/generic/builders/button.rb
+++ b/lib/design_system/generic/builders/button.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module DesignSystem
   module Generic
     module Builders

--- a/lib/design_system/generic/builders/fixed_elements.rb
+++ b/lib/design_system/generic/builders/fixed_elements.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-require_relative 'elements/breadcrumbs'
-require_relative 'elements/form'
-require_relative 'elements/headings'
-
 module DesignSystem
   module Generic
     module Builders

--- a/lib/design_system/generic/builders/link.rb
+++ b/lib/design_system/generic/builders/link.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module DesignSystem
   module Generic
     module Builders

--- a/lib/design_system/generic/builders/summary_list.rb
+++ b/lib/design_system/generic/builders/summary_list.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/components/summary_list'
-require_relative 'base'
-
 module DesignSystem
   module Generic
     module Builders

--- a/lib/design_system/generic/builders/tab.rb
+++ b/lib/design_system/generic/builders/tab.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/components/tab'
-require_relative 'base'
-
 module DesignSystem
   module Generic
     module Builders

--- a/lib/design_system/generic/builders/table.rb
+++ b/lib/design_system/generic/builders/table.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/components/table'
-require_relative 'base'
-
 module DesignSystem
   module Generic
     module Builders

--- a/lib/design_system/govuk/builders/button.rb
+++ b/lib/design_system/govuk/builders/button.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/button'
-
 module DesignSystem
   module Govuk
     module Builders

--- a/lib/design_system/govuk/builders/fixed_elements.rb
+++ b/lib/design_system/govuk/builders/fixed_elements.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/fixed_elements'
-require_relative 'elements/breadcrumbs'
-require_relative 'elements/headings'
-
 module DesignSystem
   module Govuk
     module Builders

--- a/lib/design_system/govuk/builders/link.rb
+++ b/lib/design_system/govuk/builders/link.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/link'
-
 module DesignSystem
   module Govuk
     module Builders

--- a/lib/design_system/govuk/builders/summary_list.rb
+++ b/lib/design_system/govuk/builders/summary_list.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/summary_list'
-
 module DesignSystem
   module Govuk
     module Builders

--- a/lib/design_system/govuk/builders/tab.rb
+++ b/lib/design_system/govuk/builders/tab.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/tab'
-
 module DesignSystem
   module Govuk
     module Builders

--- a/lib/design_system/govuk/builders/table.rb
+++ b/lib/design_system/govuk/builders/table.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/table'
-
 module DesignSystem
   module Govuk
     module Builders

--- a/lib/design_system/govuk/form_builder.rb
+++ b/lib/design_system/govuk/form_builder.rb
@@ -1,4 +1,3 @@
-require 'design_system/generic/form_builder'
 require 'govuk_design_system_formbuilder'
 
 module DesignSystem

--- a/lib/design_system/nhsuk/builders/fixed_elements.rb
+++ b/lib/design_system/nhsuk/builders/fixed_elements.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/govuk/builders/fixed_elements'
-require_relative 'elements/breadcrumbs'
-
 module DesignSystem
   module Nhsuk
     module Builders

--- a/lib/design_system/nhsuk/builders/summary_list.rb
+++ b/lib/design_system/nhsuk/builders/summary_list.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'design_system/generic/builders/summary_list'
-
 module DesignSystem
   module Nhsuk
     module Builders

--- a/lib/design_system/nhsuk/form_builder.rb
+++ b/lib/design_system/nhsuk/form_builder.rb
@@ -1,5 +1,3 @@
-require 'design_system/govuk/form_builder'
-
 module DesignSystem
   # Module namespace containing all the form builders
   module Nhsuk

--- a/test/generic/builders/concerns/brand_derivable_test.rb
+++ b/test/generic/builders/concerns/brand_derivable_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require Rails.root.join('../../lib/design_system/generic/builders/concerns/brand_derivable')
 
 module DesignSystem
   module HelloWorld

--- a/test/generic/form_builder_test.rb
+++ b/test/generic/form_builder_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'design_system/govuk/form_builder'
 
 module Generic
   class FormBuilderTest < ActionView::TestCase

--- a/test/govuk/concerns/govuk_form_builder_testable.rb
+++ b/test/govuk/concerns/govuk_form_builder_testable.rb
@@ -1,5 +1,3 @@
-require 'design_system/registry'
-
 class DummyModel
   include ActiveModel::Model
 

--- a/test/govuk/form_builder_test.rb
+++ b/test/govuk/form_builder_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'design_system/govuk/form_builder'
 require_relative 'concerns/govuk_form_builder_testable'
 
 module Govuk

--- a/test/nhsuk/form_builder_test.rb
+++ b/test/nhsuk/form_builder_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'design_system/nhsuk/form_builder'
-require_relative '../govuk/concerns/govuk_form_builder_testable'
 
 module Nhsuk
   class FormBuilderTest < ActionView::TestCase

--- a/test/zeitwerk_loader_test.rb
+++ b/test/zeitwerk_loader_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ZeitwerkLoaderTest < Minitest::Test
+  def setup
+    @root = Pathname.new(File.expand_path('..', __dir__))
+
+    @loader = Zeitwerk::Loader.new
+    @loader.tag = 'design_system.rb'
+    @loader.inflector = Zeitwerk::GemInflector.new(@root.join('lib/design_system.rb'))
+    # @loader.push_dir(@root.join('test'))
+    @loader.ignore(@root.join('test/test_helper.rb'))
+    @loader.setup
+  end
+
+  def teardown
+    @loader.unload
+  end
+
+  def test_eager_load
+    @loader.eager_load(force: true)
+  rescue Zeitwerk::NameError => e
+    flunk "Eager loading failed with error: #{e.message}"
+  end
+end


### PR DESCRIPTION
## What?

I've cleaned up require calls with Zeitwerk.

## Why?

In order to extend this gem with plugins, we need to add Zeitwerk to the gem. It also helps ensure namespaced class names match file paths.

## How?

Having added:

```ruby
loader = Zeitwerk::Loader.for_gem
loader.setup
```

I have removed the vast majority of (internal) require and require_relative calls. I've also added a Zeitwerk test to eagerly load the project to ensure that naming conventions are adhered to.

## Testing?

All tests continue to pass.

## Anything Else?

No