### PR TITLE
Fixed the autoload conflict with Zeitwerk in dev mode

### DIFF
--- a/lib/design_system/engine.rb
+++ b/lib/design_system/engine.rb
@@ -4,9 +4,6 @@ require 'stimulus-rails'
 module DesignSystem
   # This is the main engine class for the design system.
   class Engine < ::Rails::Engine
-    # Allow changes to the design system to be reloaded in development.
-    config.autoload_paths << File.expand_path('..', __dir__) if Rails.env.development?
-
     initializer 'design_system.importmap', before: 'importmap' do |app|
       app.config.importmap.paths << Engine.root.join('config/importmap.rb')
     end


### PR DESCRIPTION
## What?

I've fixed the autoload conflict with Zeitwerk in dev mode.

## Why?

I was wrongly adding the lib folder to the autoload_paths in Rails development mode, but this clashed with the tracking of the lib folder using Zeitwerk directly.

## How?

I updated the `engine.rb` file, removing the offending line of config.

## Testing?

Tests continue to pass and the dummy app has been tested in dev mode manually.

## Anything Else?

No