### PR TITLE
CHANGELOG update and link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-09-04
+
 ### Added
 
 - Added the ability to manage footer links and copyright notice
@@ -28,5 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added FormBuilders to with Rails signatures (where possible)
 - Supports multiple layouts
 
-[unreleased]: https://github.com/HealthDataInsight/structured_store/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/HealthDataInsight/structured_store/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/HealthDataInsight/structured_store/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/HealthDataInsight/structured_store/releases/tag/v0.7.0

--- a/design_system.gemspec
+++ b/design_system.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/HealthDataInsight/design_system'
-  spec.metadata['changelog_uri'] = 'https://github.com/HealthDataInsight/design_system/CHANGELOG.md'
+  spec.metadata['changelog_uri'] = 'https://github.com/HealthDataInsight/design_system/blob/main/CHANGELOG.md'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir['{app,config,db,lib,public}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']


### PR DESCRIPTION
## What?

I've updated the CHANGELOG and fixed the gemspec link to it.

## Why?

Version 0.8.0 has now been published and the rubygem link to the changelog was broken.

## How?

Unreleased changes are all now part of v0.8.0.

## Testing?

N/A

## Anything Else?

No