### PR TITLE
Code safety run for 9.0

### DIFF
--- a/test/dummy/config/code_safety.yml
+++ b/test/dummy/config/code_safety.yml
@@ -55,7 +55,7 @@ file safety:
   CHANGELOG.md:
     comments:
     reviewed_by: shilpigoeldev
-    safe_revision: 8e14b1363a1a44d5cbf9a3994e3fb2c505d4290a
+    safe_revision: cb0ed880961c20afc54c3880df9aa814f3bd35ae
   CODE_OF_CONDUCT.md:
     comments:
     reviewed_by: timgentry
@@ -67,7 +67,7 @@ file safety:
   Gemfile.lock:
     comments:
     reviewed_by: shilpigoeldev
-    safe_revision: 8e14b1363a1a44d5cbf9a3994e3fb2c505d4290a
+    safe_revision: cb0ed880961c20afc54c3880df9aa814f3bd35ae
   MIT-LICENSE:
     comments:
     reviewed_by: timgentry
@@ -1531,7 +1531,7 @@ file safety:
   lib/design_system/version.rb:
     comments:
     reviewed_by: shilpigoeldev
-    safe_revision: 8e14b1363a1a44d5cbf9a3994e3fb2c505d4290a
+    safe_revision: cb0ed880961c20afc54c3880df9aa814f3bd35ae
   lib/tasks/design_system_tasks.rake:
     comments:
     reviewed_by: shilpigoeldev
@@ -1554,8 +1554,8 @@ file safety:
     safe_revision: cbe855bc549f64f2340c3d49271bfd446dc01315
   public/design_system/static/design_system-0.9.0/design_system.js:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: shilpigoeldev
+    safe_revision: cb0ed880961c20afc54c3880df9aa814f3bd35ae
   public/design_system/static/govuk-frontend-5.11.1/fonts/bold-affa96571d-v2.woff:
     comments:
     reviewed_by: timgentry


### PR DESCRIPTION
## What?

Code safety run for releasing version 9.0

## Why?

Needed for gem release

## How?

via rake task - bundle exec rake audit:code interactive=true reviewed_by=shilpigoeldev

## Testing?

N/A

