### PR TITLE
Zeitwerk fix for autoloading all.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2025-10-08
+
+### Fixed
+
+- Fixed Zeitwerk on_file_autoloaded issue for all.rb (by adding it to ignore list)
+
 ## [0.9.0] - 2025-10-06
 
 ### Changed
@@ -49,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added FormBuilders to with Rails signatures (where possible)
 - Supports multiple layouts
 
-[unreleased]: https://github.com/HealthDataInsight/design_system/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/HealthDataInsight/design_system/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/HealthDataInsight/design_system/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/HealthDataInsight/design_system/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/HealthDataInsight/design_system/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/HealthDataInsight/design_system/compare/v0.7.0...v0.8.0

--- a/lib/design_system.rb
+++ b/lib/design_system.rb
@@ -5,6 +5,9 @@ loader = Zeitwerk::Loader.for_gem
 # Avoid loading test helpers by default
 loader.ignore("#{__dir__}/design_system/*/test_helpers")
 
+# Avoid loading the all file to prevent circular dependencies
+loader.ignore("#{__dir__}/design_system/all")
+
 loader.setup
 
 require 'design_system/version'


### PR DESCRIPTION
## What?

Have made Zeitwerk happy by ignoring autoloading of all.rb

## Why?

This was causing error in api_upload_portal - 

`2.7.3/lib/zeitwerk/loader/callbacks.rb:31:in `on_file_autoloaded': expected file /home/runner/work/api_upload_portal/api_upload_portal/vendor/bundle/ruby/3.3.0/gems/design_system-0.9.0/lib/design_system/all.rb to define constant DesignSystem::All, but didn't (Zeitwerk::NameError)`

## How?

By adding it to ignore list

## Testing?

Tests pass

## Anything Else?

Changelog updated for next version bump.
Would need code safety review for the changes.
