### PR TITLE
making Zeitwerk happy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Adding a stub class for all.rb to make zeitwerk happy
+
 ## [0.9.1] - 2025-10-08
 
 ### Fixed

--- a/lib/design_system/all.rb
+++ b/lib/design_system/all.rb
@@ -1,3 +1,10 @@
 require_relative 'generic'
 require_relative 'govuk'
 require_relative 'nhsuk'
+module DesignSystem
+  # Make zeitwerk happy by defining a stub class
+  # rubocop:disable Lint/EmptyClass
+  class All
+  end
+  # rubocop:enable Lint/EmptyClass
+end


### PR DESCRIPTION
## What?

Added stub class to make zeitwerk happy for all.rb.

## Why?

This is causing error on api_upload_portal - 
```
2.7.3/lib/zeitwerk/loader/callbacks.rb:31:in `on_file_autoloaded': expected file /home/runner/work/api_upload_portal/api_upload_portal/vendor/bundle/ruby/3.3.0/gems/design_system-0.9.1/lib/design_system/all.rb to define constant DesignSystem::All, but didn't (Zeitwerk::NameError)

      raise Zeitwerk::NameError.new(msg, cref.cname)
```

## How?

By defining an empty class.

## Testing?

Tests pass