### PR TITLE
Only configure importmap paths if using importmaps

### DIFF
--- a/lib/design_system/engine.rb
+++ b/lib/design_system/engine.rb
@@ -5,7 +5,7 @@ module DesignSystem
   # This is the main engine class for the design system.
   class Engine < ::Rails::Engine
     initializer 'design_system.importmap', before: 'importmap' do |app|
-      app.config.importmap.paths << Engine.root.join('config/importmap.rb')
+      app.config.importmap.paths << Engine.root.join('config/importmap.rb') if app.config.respond_to?(:importmap)
     end
 
     # Adding Rack::Static to serve up assets from the design_systems


### PR DESCRIPTION
## What?

I've updated the engine to only add to the consuming app's importmap paths if they are using importmaps.

## Why?

Not all consuming projects use importmaps.

## How?

If the app's config responds to importmap, then it's using importmaps.

## Testing?

This has been tested in a consuming app that doesn't use importmaps.

## Anything Else?

No