### PR TITLE
details component added resolves #213

### DIFF
--- a/app/helpers/design_system_helper.rb
+++ b/app/helpers/design_system_helper.rb
@@ -108,4 +108,10 @@ module DesignSystemHelper
   def ds_callout(label, body)
     DesignSystem::Registry.builder(brand, 'callout', self).render_callout(label, body)
   end
+
+  def ds_details(summary_text, &)
+    raise ArgumentError unless block_given?
+
+    DesignSystem::Registry.builder(brand, 'details', self).render_details(summary_text, &)
+  end
 end

--- a/lib/design_system/generic.rb
+++ b/lib/design_system/generic.rb
@@ -5,6 +5,7 @@
 require_relative 'generic/builders/concerns/brand_derivable'
 require_relative 'generic/builders/button'
 require_relative 'generic/builders/callout'
+require_relative 'generic/builders/details'
 require_relative 'generic/builders/fixed_elements'
 require_relative 'generic/builders/heading'
 require_relative 'generic/builders/link'

--- a/lib/design_system/generic/builders/details.rb
+++ b/lib/design_system/generic/builders/details.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Generic
+    module Builders
+      # This builds a generic details component with brand-specific classes
+      class Details < Base
+        def render_details(summary_text)
+          content = capture { yield if block_given? }
+
+          content_tag(:details, class: "#{brand}-details") do
+            safe_buffer = ActiveSupport::SafeBuffer.new
+
+            safe_buffer.concat(
+              content_tag(:summary, class: "#{brand}-details__summary") do
+                content_tag(:span, summary_text, class: "#{brand}-details__summary-text")
+              end
+            )
+
+            safe_buffer.concat(
+              content_tag(:div, content, class: "#{brand}-details__text")
+            )
+
+            safe_buffer
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/design_system/govuk.rb
+++ b/lib/design_system/govuk.rb
@@ -4,6 +4,7 @@
 
 require_relative 'govuk/builders/button'
 require_relative 'govuk/builders/callout'
+require_relative 'govuk/builders/details'
 require_relative 'govuk/builders/fixed_elements'
 require_relative 'govuk/builders/heading'
 require_relative 'govuk/builders/link'

--- a/lib/design_system/govuk/builders/details.rb
+++ b/lib/design_system/govuk/builders/details.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Govuk
+    module Builders
+      class Details < ::DesignSystem::Generic::Builders::Details
+      end
+    end
+  end
+end

--- a/lib/design_system/nhsuk.rb
+++ b/lib/design_system/nhsuk.rb
@@ -3,6 +3,7 @@
 require_relative 'nhsuk/builders/button'
 require_relative 'nhsuk/builders/callout'
 require_relative 'nhsuk/builders/fixed_elements'
+require_relative 'nhsuk/builders/details'
 require_relative 'nhsuk/builders/heading'
 require_relative 'nhsuk/builders/link'
 require_relative 'nhsuk/builders/notification'

--- a/lib/design_system/nhsuk/builders/details.rb
+++ b/lib/design_system/nhsuk/builders/details.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  module Nhsuk
+    module Builders
+      class Details < ::DesignSystem::Generic::Builders::Details
+      end
+    end
+  end
+end

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -132,3 +132,16 @@ end
 <%= ds_callout('School Message:', 'Half term break is over !!') %>
 
 
+<%= ds_heading 'Details' %>
+<%= ds_details('How to find your NHS number') do %>
+  <p>
+    You can find your NHS number by logging in to the NHS App or on any document the NHS has sent you, such as your:
+  </p>
+  <ul>
+    <li>hospital referral letters</li>
+    <li>appointment letters</li>
+  </ul>
+  <p>Ask your GP surgery for help if you cannot find your NHS number.</p>
+<% end %>
+
+

--- a/test/govuk/builders/details_test.rb
+++ b/test/govuk/builders/details_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DesignSystem
+  module Govuk
+    module Builders
+      class DetailsTest < ActionView::TestCase
+        include DesignSystemHelper
+
+        setup do
+          @brand = 'govuk'
+          @controller.stubs(:brand).returns(@brand)
+        end
+
+        test 'renders govuk details with summary and block content' do
+          @output_buffer = ds_details('How to find your NHS number') do
+            content_tag(:p, 'Example details text')
+          end
+
+          assert_select 'details.govuk-details' do
+            assert_select 'summary.govuk-details__summary' do
+              assert_select 'span.govuk-details__summary-text', text: 'How to find your NHS number'
+            end
+            assert_select 'div.govuk-details__text' do
+              assert_select 'p', text: 'Example details text'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/nhsuk/builders/details_test.rb
+++ b/test/nhsuk/builders/details_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DesignSystem
+  module Nhsuk
+    module Builders
+      class DetailsTest < ActionView::TestCase
+        include DesignSystemHelper
+
+        setup do
+          @brand = 'nhsuk'
+          @controller.stubs(:brand).returns(@brand)
+        end
+
+        test 'renders nhsuk details with summary and block content' do
+          @output_buffer = ds_details('How to find your NHS number') do
+            content_tag(:p, 'Example details text')
+          end
+
+          assert_select 'details.nhsuk-details' do
+            assert_select 'summary.nhsuk-details__summary' do
+              assert_select 'span.nhsuk-details__summary-text', text: 'How to find your NHS number'
+            end
+            assert_select 'div.nhsuk-details__text' do
+              assert_select 'p', text: 'Example details text'
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What?

I've added details component for Design System. This resolves https://github.com/HealthDataInsight/design_system/issues/213

## Why?

While working on DSification of audits in era, we realised we are missing on Details component helper in DS.

## How?
By adding a details generic builder to render the needed html. This helper method accepts block to be rendered as details and text as details summary.

## Testing?

Tests have been added and are passing.

## Screenshots (optional)
NHS UK-
<img width="822" height="297" alt="Screenshot 2026-01-06 at 14 32 33" src="https://github.com/user-attachments/assets/10619fec-4493-4f71-848e-1ea198e5bb10" />
GOV UK-
<img width="789" height="252" alt="Screenshot 2026-01-06 at 14 41 18" src="https://github.com/user-attachments/assets/d2127912-8ba5-4c4f-9992-73f9fe5de1e0" />

## Anything else?
HDI equivalent component ticket has been logged at https://github.com/HealthDataInsight/design_system-hdi/issues/14
