### PR TITLE
Handle if check_box label value ends with dot

### DIFF
--- a/lib/design_system/govuk/form_builder.rb
+++ b/lib/design_system/govuk/form_builder.rb
@@ -405,12 +405,16 @@ module DesignSystem
         # If translation returns the humanized version of the value,
         # it means no translation was found, so return the original value
         # Extra condition: if value contains dots and translation is only the last part
-        if translation == value.to_s.humanize ||
-           (value.to_s.include?('.') && translation == value.to_s.split('.').last.humanize)
+        if translation == value.to_s.humanize || value_contains_dots?(value, translation)
           value.to_s
         else
           translation
         end
+      end
+
+      def value_contains_dots?(value, translation)
+        (value.to_s.include?('.') && translation == value.to_s.split('.').last.humanize) ||
+          (value.to_s.ends_with?('.') && translation.blank?)
       end
 
       # GOVUKDesignSystemFormBuilder::Base field_id method

--- a/lib/design_system/govuk/test_helpers/form_builder_testable.rb
+++ b/lib/design_system/govuk/test_helpers/form_builder_testable.rb
@@ -137,6 +137,20 @@ module DesignSystem
             end
           end
 
+          test 'ds_check_box item ending with dot in value is not incorrectly translated' do
+            value_ending_with_dot = 'Made up dummy values with a full stop.'
+            @output_buffer = ds_form_with(model: DummyModel.new, builder: @builder, url: '/') do |f|
+              f.ds_check_box(:role, {}, value_ending_with_dot)
+            end
+
+            assert_select('form') do
+              assert_select("div.#{@brand}-checkboxes__item") do
+                label = assert_select("label.#{@brand}-label.#{@brand}-checkboxes__label").first
+                assert_equal value_ending_with_dot, label.text.strip
+              end
+            end
+          end
+
           test 'ds_collection_select' do
             @output_buffer = ds_form_with(model: assistants(:one), builder: @builder) do |f|
               f.ds_collection_select(:department_id, Department.all, :id, :title)


### PR DESCRIPTION
## What?

Handle if ds_check_box label value ends with '.'

## Why?

"ds_check_box" breaks when there is a full stop at the end of the text. See https://github.com/HealthDataInsight/design_system/issues/218

In Rails, calling value.to_s.split('.').last on a string ending in a dot returns the segment before the dot. This causes a mismatch between the processed string and the actual translation key, leading to a false evaluation and broken rendering.

## How?

This PR updates the label handling logic to correctly account for trailing periods, ensuring the helper accurately matches the full label value.

## Testing?

All passed

## Screenshots (optional)

N/A

## Anything Else?

No