### PR TITLE
Wrap banner content headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed notification banner content heading
+
 ## [0.13.2] - 2026-03-17
 
 ### Fixed

--- a/app/helpers/design_system_helper.rb
+++ b/app/helpers/design_system_helper.rb
@@ -78,8 +78,8 @@ module DesignSystemHelper
     DesignSystem::Registry.builder(brand, 'notification', self).render_alert(message, &)
   end
 
-  def ds_notice(message = nil, header: nil, type: :information, &)
-    DesignSystem::Registry.builder(brand, 'notification', self).render_notice(message, header:, type:, &)
+  def ds_notice(message = nil, type: :information, content_heading: { text: nil, tag: :h3 }, &)
+    DesignSystem::Registry.builder(brand, 'notification', self).render_notice(message, type:, content_heading:, &)
   end
 
   def ds_heading(text, level: 2, **options)

--- a/lib/design_system/generic/builders/notification.rb
+++ b/lib/design_system/generic/builders/notification.rb
@@ -29,6 +29,8 @@ module DesignSystem
 
           content_body = block_given? ? capture(&) : msg
 
+          validate_content_heading_tag!(content_heading)
+
           content_tag(:div, class: notification_type_hash.dig(type, :class), role: notification_type_hash.dig(type, :role),
                             'aria-labelledby': "#{brand}-notification-banner-title",
                             'data-module': "#{brand}-notification-banner") do
@@ -57,6 +59,16 @@ module DesignSystem
 
             safe_join(content)
           end
+        end
+
+        def validate_content_heading_tag!(content_heading)
+          tag = content_heading&.[](:tag)
+          return if tag.blank?
+
+          allowed = %i[p h1 h2 h3 h4 h5 h6]
+          return if allowed.include?(tag.to_sym)
+
+          raise ArgumentError, "Invalid content_heading tag: #{tag}. Must be one of: #{allowed.join(', ')}"
         end
 
         def notification_type_hash

--- a/lib/design_system/generic/builders/notification.rb
+++ b/lib/design_system/generic/builders/notification.rb
@@ -5,6 +5,7 @@ module DesignSystem
     module Builders
       # This class provides generic methods to display notifications.
       class Notification < Base
+        include ActionView::Helpers::OutputSafetyHelper
         include ActionView::Helpers::SanitizeHelper
 
         def render_alert(msg = nil, &)
@@ -19,8 +20,10 @@ module DesignSystem
         def render_notice(msg = nil, type: :information, content_heading: { text: nil, tag: :h3 }, &)
           @context.instance_variable_set(:@link_context, :notification_banner)
 
-          raise ArgumentError,
-                "Invalid notification type: #{type}. Must be one of: #{notification_type_hash.keys.join(', ')}" unless notification_type_hash.key?(type)
+          unless notification_type_hash.key?(type)
+            raise ArgumentError,
+                  "Invalid notification type: #{type}. Must be one of: #{notification_type_hash.keys.join(', ')}"
+          end
 
           header = notification_type_hash.dig(type, :header)
 
@@ -45,11 +48,14 @@ module DesignSystem
         def banner_content(content_heading, content_body)
           content_tag(:div, class: "#{brand}-notification-banner__content") do
             content = []
-            
-            content << content_tag(content_heading[:tag], content_heading[:text], class: "#{brand}-notification-banner__heading") if content_heading[:text].present?
+
+            if content_heading[:text].present?
+              content << content_tag(content_heading[:tag], content_heading[:text],
+                                     class: "#{brand}-notification-banner__heading")
+            end
             content << content_body if content_body.present?
 
-            content.join.html_safe
+            safe_join(content)
           end
         end
 

--- a/lib/design_system/generic/builders/notification.rb
+++ b/lib/design_system/generic/builders/notification.rb
@@ -16,19 +16,20 @@ module DesignSystem
           end
         end
 
-        def render_notice(msg = nil, header: nil, type: :information, &)
+        def render_notice(msg = nil, type: :information, content_heading: { text: nil, tag: :h3 }, &)
           @context.instance_variable_set(:@link_context, :notification_banner)
 
           raise ArgumentError,
                 "Invalid notification type: #{type}. Must be one of: #{notification_type_hash.keys.join(', ')}" unless notification_type_hash.key?(type)
 
-          header ||= notification_type_hash.dig(type, :header)
+          header = notification_type_hash.dig(type, :header)
 
-          content_to_display = block_given? ? capture(&) : msg
+          content_body = block_given? ? capture(&) : msg
+
           content_tag(:div, class: notification_type_hash.dig(type, :class), role: notification_type_hash.dig(type, :role),
                             'aria-labelledby': "#{brand}-notification-banner-title",
                             'data-module': "#{brand}-notification-banner") do
-            banner_tile(header) + banner_content(content_to_display)
+            banner_tile(header) + banner_content(content_heading, content_body)
           end
         end
 
@@ -41,10 +42,14 @@ module DesignSystem
           end
         end
 
-        def banner_content(content)
+        def banner_content(content_heading, content_body)
           content_tag(:div, class: "#{brand}-notification-banner__content") do
-            content_tag(:p, content,
-                        class: "#{brand}-notification-banner__heading")
+            content = []
+            
+            content << content_tag(content_heading[:tag], content_heading[:text], class: "#{brand}-notification-banner__heading") if content_heading[:text].present?
+            content << content_body if content_body.present?
+
+            content.join.html_safe
           end
         end
 

--- a/lib/design_system/generic/builders/notification.rb
+++ b/lib/design_system/generic/builders/notification.rb
@@ -29,12 +29,10 @@ module DesignSystem
 
           content_body = block_given? ? capture(&) : msg
 
-          validate_content_heading_tag!(content_heading)
-
           content_tag(:div, class: notification_type_hash.dig(type, :class), role: notification_type_hash.dig(type, :role),
                             'aria-labelledby': "#{brand}-notification-banner-title",
                             'data-module': "#{brand}-notification-banner") do
-            banner_tile(header) + banner_content(content_heading, content_body)
+            banner_tile(header) + banner_content(content_body, content_heading:)
           end
         end
 
@@ -47,28 +45,20 @@ module DesignSystem
           end
         end
 
-        def banner_content(content_heading, content_body)
+        def banner_content(content_body, content_heading: {})
           content_tag(:div, class: "#{brand}-notification-banner__content") do
             content = []
 
-            if content_heading[:text].present?
-              content << content_tag(content_heading[:tag], content_heading[:text],
-                                     class: "#{brand}-notification-banner__heading")
+            if content_heading.present? && content_heading[:text].present?
+              tag = content_heading[:tag] || :h3
+              raise ArgumentError, "Invalid content_heading tag: #{tag}.}" unless tag.in?(%i[h3 p])
+
+              content << content_tag(tag, content_heading[:text], class: "#{brand}-notification-banner__heading")
             end
             content << content_body if content_body.present?
 
             safe_join(content)
           end
-        end
-
-        def validate_content_heading_tag!(content_heading)
-          tag = content_heading&.[](:tag)
-          return if tag.blank?
-
-          allowed = %i[p h1 h2 h3 h4 h5 h6]
-          return if allowed.include?(tag.to_sym)
-
-          raise ArgumentError, "Invalid content_heading tag: #{tag}. Must be one of: #{allowed.join(', ')}"
         end
 
         def notification_type_hash

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -7,7 +7,7 @@
   <strong>Alert with block:</strong> This is a more complex alert with <a href="#">a link</a> and formatted content.
 <% end %>
 
-<%= ds_notice(content_heading: { text: 'Notice with block', tag: :h3 }) do %>
+<%= ds_notice(type: :success, content_heading: { text: 'Notice with block', tag: :h3 }) do %>
   You can include multiple elements and <%= ds_link_to 'demo', assistants_path %> link.
 <% end %>
 

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -7,11 +7,10 @@
   <strong>Alert with block:</strong> This is a more complex alert with <a href="#">a link</a> and formatted content.
 <% end %>
 
-<%= ds_notice do %>
-  <strong>Notice with block:</strong>
-  <br>
+<%= ds_notice(content_heading: { text: 'Notice with block', tag: :h3 }) do %>
   You can include multiple elements and <%= ds_link_to 'demo', assistants_path %> link.
 <% end %>
+
 <%=
 ds_fixed_elements do |ds|
   ds.breadcrumb 'One', root_path

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -7,9 +7,11 @@
   <strong>Alert with block:</strong> This is a more complex alert with <a href="#">a link</a> and formatted content.
 <% end %>
 
-<%= ds_notice(type: :success, content_heading: { text: 'Notice with block', tag: :h3 }) do %>
+<%= ds_notice(type: :success, content_heading: { text: 'Notice with block' }) do %>
   You can include multiple elements and <%= ds_link_to 'demo', assistants_path %> link.
 <% end %>
+
+<%= ds_notice(content_heading: { text: 'The service will be unavaialble from 8pm to 9pm on Thursday 1 January 2025.', tag: :p }) %>
 
 <%=
 ds_fixed_elements do |ds|

--- a/test/govuk/builders/notification_test.rb
+++ b/test/govuk/builders/notification_test.rb
@@ -21,21 +21,9 @@ module DesignSystem
             assert_select 'div.govuk-notification-banner__header' do
               assert_select 'h2.govuk-notification-banner__title', 'Important'
             end
-
-            assert_select 'div.govuk-notification-banner__content' do
-              assert_select 'p.govuk-notification-banner__heading', 'Important Notice'
-            end
           end
-        end
 
-        test 'rendering govuk notice with custom header' do
-          @output_buffer = ds_notice('Test content', header: 'Custom header')
-
-          assert_select 'div.govuk-notification-banner[role="region"][aria-labelledby="govuk-notification-banner-title"][data-module="govuk-notification-banner"]' do
-            assert_select 'div.govuk-notification-banner__header' do
-              assert_select 'h2.govuk-notification-banner__title[id="govuk-notification-banner-title"]', 'Custom header'
-            end
-          end
+          assert_select 'div.govuk-notification-banner__content', text: 'Important Notice'
         end
 
         test 'rendering govuk notice with success type' do
@@ -46,23 +34,7 @@ module DesignSystem
               assert_select 'h2.govuk-notification-banner__title[id="govuk-notification-banner-title"]', 'Success'
             end
 
-            assert_select 'div.govuk-notification-banner__content' do
-              assert_select 'p.govuk-notification-banner__heading', 'Test content'
-            end
-          end
-        end
-
-        test 'rendering govuk notice with success type and custom header' do
-          @output_buffer = ds_notice('Test content', type: :success, header: 'Custom header')
-
-          assert_select 'div.govuk-notification-banner.govuk-notification-banner--success[role="alert"][aria-labelledby="govuk-notification-banner-title"][data-module="govuk-notification-banner"]' do
-            assert_select 'div.govuk-notification-banner__header' do
-              assert_select 'h2.govuk-notification-banner__title[id="govuk-notification-banner-title"]', 'Custom header'
-            end
-
-            assert_select 'div.govuk-notification-banner__content' do
-              assert_select 'p.govuk-notification-banner__heading', 'Test content'
-            end
+            assert_select 'div.govuk-notification-banner__content', text: 'Test content'
           end
         end
 
@@ -74,18 +46,33 @@ module DesignSystem
           end
         end
 
-        test 'rendering govuk notice with block' do
+        test 'rendering govuk notice with content heading and body (msg)' do
+          @output_buffer = ds_notice('Important Notice', content_heading: { text: 'Important Notice', tag: :h1 })
+
+          assert_select 'div.govuk-notification-banner__content' do
+            assert_select 'h1.govuk-notification-banner__heading', 'Important Notice'
+          end
+        end
+
+        test 'rendering govuk notice without content heading' do
           @output_buffer = ds_notice do
-            '<strong>Notice:</strong> Complex content with <a href="#">link</a>'.html_safe
+            '<p class="custom">Raw content</p>'.html_safe
           end
 
-          assert_select 'div.govuk-notification-banner' do
-            assert_select 'div.govuk-notification-banner__content' do
-              assert_select 'p.govuk-notification-banner__heading' do
-                assert_select 'strong', 'Notice:'
-                assert_select 'a[href="#"]', 'link'
-              end
-            end
+          assert_select 'div.govuk-notification-banner__content' do
+            assert_select 'p.custom', 'Raw content'
+            assert_select '.govuk-notification-banner__heading', count: 0
+          end
+        end
+
+        test 'rendering govuk notice with heading and body(block)' do
+          @output_buffer = ds_notice(content_heading: { text: 'Banner heading', tag: :h3 }) do
+            '<p class="body">Additional content</p>'.html_safe
+          end
+
+          assert_select 'div.govuk-notification-banner__content' do
+            assert_select 'h3.govuk-notification-banner__heading', 'Banner heading'
+            assert_select 'p.body', 'Additional content'
           end
         end
 
@@ -96,22 +83,7 @@ module DesignSystem
 
           assert_select 'div.govuk-notification-banner' do
             assert_select 'div.govuk-notification-banner__content' do
-              assert_select 'p.govuk-notification-banner__heading' do
-                assert_select 'a.govuk-notification-banner__link[href="#"]', 'link'
-              end
-            end
-          end
-        end
-
-        test 'rendering govuk alert with block' do
-          @output_buffer = ds_alert do
-            '<strong>Error:</strong> Check <a href="/help">help page</a>'.html_safe
-          end
-
-          assert_select 'div.govuk-error-summary' do
-            assert_select 'h2.govuk-error-summary__title' do
-              assert_select 'strong', 'Error:'
-              assert_select 'a[href="/help"]', 'help page'
+              assert_select 'a.govuk-notification-banner__link[href="#"]', 'link'
             end
           end
         end

--- a/test/govuk/builders/notification_test.rb
+++ b/test/govuk/builders/notification_test.rb
@@ -47,10 +47,18 @@ module DesignSystem
         end
 
         test 'rendering govuk notice with content heading and body (msg)' do
-          @output_buffer = ds_notice('Important Notice', content_heading: { text: 'Important Notice', tag: :h1 })
+          @output_buffer = ds_notice('Important Notice', content_heading: { text: 'Important Notice', tag: :p })
 
           assert_select 'div.govuk-notification-banner__content' do
-            assert_select 'h1.govuk-notification-banner__heading', 'Important Notice'
+            assert_select 'p.govuk-notification-banner__heading', 'Important Notice'
+          end
+        end
+
+        test 'rendering govuk notice with content heading default tag' do
+          @output_buffer = ds_notice('Body', content_heading: { text: 'Important Notice' })
+
+          assert_select 'div.govuk-notification-banner__content' do
+            assert_select 'h3.govuk-notification-banner__heading', 'Important Notice'
           end
         end
 

--- a/test/govuk/builders/notification_test.rb
+++ b/test/govuk/builders/notification_test.rb
@@ -54,6 +54,14 @@ module DesignSystem
           end
         end
 
+        test 'rejecting invalid content heading tag' do
+          error = assert_raises(ArgumentError) do
+            ds_notice('Body', content_heading: { text: 'Heading', tag: :div })
+          end
+
+          assert_match(/Invalid content_heading tag/i, error.message)
+        end
+
         test 'rendering govuk notice without content heading' do
           @output_buffer = ds_notice do
             '<p class="custom">Raw content</p>'.html_safe

--- a/test/nhsuk/builders/notification_test.rb
+++ b/test/nhsuk/builders/notification_test.rb
@@ -22,19 +22,7 @@ module DesignSystem
               assert_select 'h2.nhsuk-notification-banner__title', 'Important'
             end
 
-            assert_select 'div.nhsuk-notification-banner__content' do
-              assert_select 'p.nhsuk-notification-banner__heading', 'Important Notice'
-            end
-          end
-        end
-
-        test 'rendering nhsuk notice with custom header' do
-          @output_buffer = ds_notice('Test content', header: 'Custom header')
-
-          assert_select 'div.nhsuk-notification-banner[role="region"][aria-labelledby="nhsuk-notification-banner-title"][data-module="nhsuk-notification-banner"]' do
-            assert_select 'div.nhsuk-notification-banner__header' do
-              assert_select 'h2.nhsuk-notification-banner__title[id="nhsuk-notification-banner-title"]', 'Custom header'
-            end
+            assert_select 'div.nhsuk-notification-banner__content', text: 'Important Notice'
           end
         end
 
@@ -46,39 +34,45 @@ module DesignSystem
               assert_select 'h2.nhsuk-notification-banner__title[id="nhsuk-notification-banner-title"]', 'Success'
             end
 
-            assert_select 'div.nhsuk-notification-banner__content' do
-              assert_select 'p.nhsuk-notification-banner__heading', 'Test content'
-            end
+            assert_select 'div.nhsuk-notification-banner__content', text: 'Test content'
           end
         end
 
-        test 'rendering nhsuk notice with success type and custom header' do
-          @output_buffer = ds_notice('Test content', type: :success, header: 'Custom header')
+        test 'rendering nhsuk alert' do
+          @output_buffer = ds_alert('Test alert!')
 
-          assert_select 'div.nhsuk-notification-banner.nhsuk-notification-banner--success[role="alert"][aria-labelledby="nhsuk-notification-banner-title"][data-module="nhsuk-notification-banner"]' do
-            assert_select 'div.nhsuk-notification-banner__header' do
-              assert_select 'h2.nhsuk-notification-banner__title[id="nhsuk-notification-banner-title"]', 'Custom header'
-            end
-
-            assert_select 'div.nhsuk-notification-banner__content' do
-              assert_select 'p.nhsuk-notification-banner__heading', 'Test content'
-            end
+          assert_select 'div.nhsuk-error-summary' do
+            assert_select 'h2.nhsuk-error-summary__title', 'Test alert!'
           end
         end
 
-        test 'rendering nhsuk notice with HTML content via block' do
+        test 'rendering nhsuk notice with content heading and body (msg)' do
+          @output_buffer = ds_notice('Body', content_heading: { text: 'Important Notice', tag: :p })
+
+          assert_select 'div.nhsuk-notification-banner__content' do
+            assert_select 'p.nhsuk-notification-banner__heading', 'Important Notice'
+          end
+        end
+
+        test 'rendering nhsuk notice without content heading' do
           @output_buffer = ds_notice do
-            '<b>Important Notice:<br> check link <a href="/"> here </a></b>'.html_safe
+            '<p class="custom">Raw content</p>'.html_safe
           end
 
-          assert_select 'div.nhsuk-notification-banner' do
-            assert_select 'div.nhsuk-notification-banner__content' do
-              assert_select 'p.nhsuk-notification-banner__heading' do
-                assert_select 'b', text: 'Important Notice: check link  here' do
-                  assert_select 'a', text: 'here'
-                end
-              end
-            end
+          assert_select 'div.nhsuk-notification-banner__content' do
+            assert_select 'p.custom', 'Raw content'
+            assert_select '.nhsuk-notification-banner__heading', count: 0
+          end
+        end
+
+        test 'rendering nhsuk notice with heading and body(block)' do
+          @output_buffer = ds_notice(content_heading: { text: 'Banner heading', tag: :h3 }) do
+            '<p class="body">Additional content</p>'.html_safe
+          end
+
+          assert_select 'div.nhsuk-notification-banner__content' do
+            assert_select 'h3.nhsuk-notification-banner__heading', 'Banner heading'
+            assert_select 'p.body', 'Additional content'
           end
         end
 
@@ -89,9 +83,7 @@ module DesignSystem
 
           assert_select 'div.nhsuk-notification-banner' do
             assert_select 'div.nhsuk-notification-banner__content' do
-              assert_select 'p.nhsuk-notification-banner__heading' do
-                assert_select 'a.nhsuk-notification-banner__link[href="#"]', 'link'
-              end
+              assert_select 'a.nhsuk-notification-banner__link[href="#"]', 'link'
             end
           end
         end

--- a/test/nhsuk/builders/notification_test.rb
+++ b/test/nhsuk/builders/notification_test.rb
@@ -54,6 +54,14 @@ module DesignSystem
           end
         end
 
+        test 'rejecting invalid content heading tag' do
+          error = assert_raises(ArgumentError) do
+            ds_notice('Body', content_heading: { text: 'Heading', tag: :div })
+          end
+
+          assert_match(/Invalid content_heading tag/i, error.message)
+        end
+
         test 'rendering nhsuk notice without content heading' do
           @output_buffer = ds_notice do
             '<p class="custom">Raw content</p>'.html_safe

--- a/test/nhsuk/builders/notification_test.rb
+++ b/test/nhsuk/builders/notification_test.rb
@@ -54,6 +54,14 @@ module DesignSystem
           end
         end
 
+        test 'rendering nhsuk notice with content heading default tag' do
+          @output_buffer = ds_notice('Body', content_heading: { text: 'Important Notice' })
+
+          assert_select 'div.nhsuk-notification-banner__content' do
+            assert_select 'h3.nhsuk-notification-banner__heading', 'Important Notice'
+          end
+        end
+
         test 'rejecting invalid content heading tag' do
           error = assert_raises(ArgumentError) do
             ds_notice('Body', content_heading: { text: 'Heading', tag: :div })


### PR DESCRIPTION
## What?

Wrap content heading in banners

## Why?

NHSUK and GOVUK notification banners allow content to be emphasised by rendering in `-notification-banner__heading` style

## How?

Added hash argument `content_heading` to `ds_notice`, defaulting to `<h3>` tag

## Testing?

All passed

## Screenshots (optional)

<img width="1006" height="205" alt="image" src="https://github.com/user-attachments/assets/68eaeadc-af4b-4cb5-a8e0-cc9abb7639af" />

## Anything Else?

No