### PR TITLE
Security hardening: registry allowlist, route constraints, dummy CSRF cleanup

### DIFF
--- a/lib/design_system/registry.rb
+++ b/lib/design_system/registry.rb
@@ -23,13 +23,19 @@ module DesignSystem
       end
 
       def form_builder(brand)
+        raise ArgumentError, "Unknown brand: #{brand}" unless registered?(brand)
+
         "DesignSystem::#{brand.camelcase}::FormBuilder".constantize
+      end
+
+      def registered?(brand)
+        Array(design_systems).include?(brand)
       end
 
       private
 
       def namespaced_builder_klass(brand, klass_name)
-        raise ArgumentError, "Unknown brand: #{brand}" unless design_systems.include?(brand)
+        raise ArgumentError, "Unknown brand: #{brand}" unless registered?(brand)
 
         "DesignSystem::#{brand.camelize}::Builders::#{klass_name.camelize}".constantize
       end

--- a/test/design_system_registry_test.rb
+++ b/test/design_system_registry_test.rb
@@ -17,6 +17,32 @@ class DesignSystemRegistryTest < ActiveSupport::TestCase
     assert_equal 2, @registry.design_systems.count
   end
 
+  test 'registered? returns true for registered brands' do
+    assert @registry.registered?('govuk')
+    assert @registry.registered?('nhsuk')
+  end
+
+  test 'registered? returns false for unknown brands' do
+    assert_not @registry.registered?('unknown')
+    assert_not @registry.registered?(nil)
+    assert_not @registry.registered?('')
+  end
+
+  test 'form_builder raises ArgumentError for unregistered brand' do
+    assert_raises(ArgumentError) { @registry.form_builder('unknown') }
+    assert_raises(ArgumentError) { @registry.form_builder('Object') }
+    assert_raises(ArgumentError) { @registry.form_builder(nil) }
+  end
+
+  test 'form_builder returns the brand form builder for registered brands' do
+    assert_equal DesignSystem::Govuk::FormBuilder, @registry.form_builder('govuk')
+    assert_equal DesignSystem::Nhsuk::FormBuilder, @registry.form_builder('nhsuk')
+  end
+
+  test 'builder raises ArgumentError for unregistered brand' do
+    assert_raises(ArgumentError) { @registry.builder('unknown', 'heading', nil) }
+  end
+
   def teardown
     @registry = nil
   end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
 
   def brand
     session[:brand] ||= 'nhsuk'
-    session[:brand] = params[:brand] if params[:brand]
+    session[:brand] = params[:brand] if DesignSystem::Registry.registered?(params[:brand])
     session[:brand]
   end
 

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -4,8 +4,6 @@ require 'will_paginate/array'
 
 # This is the application controller
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session if Rails.env.test?
-
   include DesignSystem::Branded
 
   before_action :add_navigation, :set_service_name, :set_footer_links, :searchbar_url

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -9,8 +9,10 @@ Rails.application.routes.draw do
   root 'pages#index'
   post 'form-handler', to: 'pages#form_handler'
 
-  resources :styles, only: %i[index show], param: :style
-  resources :components, only: %i[index show], param: :component
+  resources :styles, only: %i[index show], param: :style,
+                     constraints: { style: /[a-z0-9_-]+/ }
+  resources :components, only: %i[index show], param: :component,
+                         constraints: { component: /[a-z0-9_-]+/ }
 
   resources :assistants
 end


### PR DESCRIPTION
## What?

Three small security-hardening changes surfaced by a review of this repo:

1. `DesignSystem::Registry.form_builder` and the dummy `ApplicationController#brand` are now gated on a shared `Registry.registered?` check, so brand strings that haven't been registered can't reach `String#constantize` or get persisted in the session.
2. The dummy app's `:styles`/`:components` resources now have a `[a-z0-9_-]+` route constraint, so request paths can't escape those view directories via `..` segments.
3. Removed a redundant `protect_from_forgery with: :null_session if Rails.env.test?` line in the dummy `ApplicationController` — `config.action_controller.allow_forgery_protection` is already `false` in the dummy test env, so the line was a no-op that read like a copy-paste-ready way to disable CSRF.

## Why?

`Registry.form_builder('whatever'.camelcase + '::FormBuilder').constantize` on attacker-controlled input gives a class-resolution probing primitive and, more concerningly, can trigger autoload-time side effects from arbitrary classes. The session also previously stored whatever `params[:brand]` contained. The route-constraint change closes a directory traversal in the dummy preview controllers (`render "styles/#{params[:style]}"`). The CSRF line removal is hygiene — keeping copy-paste-ready "disable CSRF" patterns out of the codebase.

## How?

- `lib/design_system/registry.rb`: added `Registry.registered?(brand)` and made both `form_builder` and `namespaced_builder_klass` raise `ArgumentError` through it. Single source of truth.
- `test/dummy/app/controllers/application_controller.rb`: `session[:brand] = params[:brand]` now only fires when the brand is registered; unregistered values fall through to the existing `'nhsuk'` default.
- `test/dummy/config/routes.rb`: added `constraints: { style: /[a-z0-9_-]+/ }` (and equivalent for `:component`). Rails anchors route-constraint regexes implicitly, so traversal is rejected at routing, not in the controller.
- `test/dummy/app/controllers/application_controller.rb`: deleted the no-op `protect_from_forgery with: :null_session` line.

## Testing?

- New tests in `test/design_system_registry_test.rb` cover `registered?`, `form_builder` raising for unregistered/nil/non-existent classes, and the existing `builder` guard.
- Existing form builder tests (`test/govuk/form_builder_test.rb`, `test/nhsuk/form_builder_test.rb`) still pass.
- Verified route constraint behaviour: `/styles/typography` resolves; `/styles/../layouts/application` and the URL-encoded equivalent are rejected at the routing layer.
- `test/controllers/assistants_controller_test.rb` (which posts/patches/deletes) and the navigation integration test still pass after removing the CSRF line — confirms it was a no-op.

## Anything Else?

These were the items from the security review that landed cleanly outside the builder tree. Other findings (builder `safe_join` hygiene, `link_to` scheme validation, `system(...)` array form in `lib/tasks/govuk.rake`, CSP/SRI documentation, `charlock_holmes` replacement) are tracked but not in this PR — the builder ones because that tree is up for refactor anyway, the others because they're lower priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)