### PR TITLE
Add a Get started guide and Utilities section to the dummy app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 megalinter-reports/
 .rubocop-https---*
 .vscode/
+.gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Refurbished the preview pages in the dummy app
+- Reworked the dummy app home page into a "Get started" guide that orients developers around the site's Styles, Components and Utilities sections, shows the bundled GOV.UK and NHS UK Frontend versions, and links to the gem, repository and changelog
+- Added a Utilities section to the dummy app for JavaScript behaviours (Stimulus controllers and time ago)
 - Added `ds_code` to render a block of code" this part is at wrong place I suppose
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ registerControllers(application)
 
 ## Updating Frontends
 
-### GOVUK Frontend (currently v5.9.0)
+### GOVUK Frontend (currently v5.11.1)
 
 ```bash
 # Automatically fetch the latest
@@ -60,7 +60,7 @@ bundle exec rake app:make_govuk
 bundle exec rake app:make_govuk\[5.9.0\]
 ```
 
-### NHSUK Frontend (currently v9.3.0)
+### NHSUK Frontend (currently v10.3.1)
 
 ```bash
 # Automatically fetch the latest

--- a/test/dummy/app/controllers/utilities_controller.rb
+++ b/test/dummy/app/controllers/utilities_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Renders design system utilities (JavaScript behaviours and helpers).
+class UtilitiesController < ApplicationController
+  layout 'two_column'
+
+  def index; end
+
+  def show
+    @utility = params[:utility]
+    render "utilities/#{@utility}"
+  rescue ActionView::MissingTemplate
+    redirect_to utilities_path
+  end
+end

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -3,6 +3,16 @@ require 'nokogiri'
 
 # Helpers for the dummy app: component preview (ERB + rendered output).
 module ApplicationHelper
+  # Bundled frontend version for a brand (e.g. "5.11.1" for govuk), read from the
+  # gem's stylesheet directory name so it stays accurate when frontends are updated.
+  def frontend_version(brand_name)
+    pattern = DesignSystem::Engine.root.join("app/assets/stylesheets/design_system/#{brand_name}-frontend-*")
+    dir = Dir.glob(pattern).first
+    return unless dir
+
+    File.basename(dir).delete_prefix("#{brand_name}-frontend-")
+  end
+
   def component_preview(key = nil, html: nil, fragment: nil, &block)
     key = key || @component || @style
     heading, reference_url = component_preview_config(key)

--- a/test/dummy/app/views/pages/_sidebar.html.erb
+++ b/test/dummy/app/views/pages/_sidebar.html.erb
@@ -1,4 +1,5 @@
 <ul class="<%= brand %>-list">
   <li class="<%= brand %>-list__item"><%= ds_link_to('Styles', styles_path) %></li>
   <li class="<%= brand %>-list__item"><%= ds_link_to('Components', components_path) %></li>
+  <li class="<%= brand %>-list__item"><%= ds_link_to('Utilities', utilities_path) %></li>
 </ul>

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -1,12 +1,16 @@
-<%= ds_notice content_heading: { text: "Design System Gem (#{DesignSystem::VERSION}) has been published." } do %>
-  <%= ds_link_to 'View on RubyGems', 'https://rubygems.org/gems/design_system' %>
+<%= ds_notice content_heading: { text: "Design System gem (v#{DesignSystem::VERSION}) is published" } do %>
+  <%= ds_paragraph do %>
+    <%= ds_link_to 'View on RubyGems', 'https://rubygems.org/gems/design_system', target: '_blank', rel: 'noopener' %> &middot;
+    <%= ds_link_to 'GitHub repository', 'https://github.com/HealthDataInsight/design_system', target: '_blank', rel: 'noopener' %> &middot;
+    <%= ds_link_to 'Changelog', 'https://github.com/HealthDataInsight/design_system/blob/main/CHANGELOG.md', target: '_blank', rel: 'noopener' %>
+  <% end %>
 <% end %>
 
 <%=
 ds_fixed_elements do |ds|
   ds.main_heading 'Get started'
 
-  # ds.form @assistant
+  ds.lead_paragraph 'This site is a living catalogue of everything the Design System gem can render. Browse it to find the markup you need, then copy it straight into your service.'
 end
 %>
 
@@ -14,16 +18,31 @@ end
   <%= render partial: 'sidebar' %>
 <% end %>
 
-<%= ds_heading 'Stimulus controllers' %>
-<div data-controller="ds--hello-world">
-  <label for="hello-world-name">Name</label>
-  <input type="text" id="hello-world-name" data-ds--hello-world-target="name">
-  <button data-action="click->ds--hello-world#greet">Greet</button>
-  <p data-ds--hello-world-target="greeting"></p>
-</div>
+<%= ds_paragraph 'Today you build each NHS and GOVUK service by hand in HTML and Bootstrap, keeping branding and accessibility right yourself. This gem does that work for you: write a few Rails helpers and get accessible, compliant markup, rendered the same way every time.' %>
+<%= ds_paragraph 'One set of ds_ helpers serves every brand. Use the GOV.UK and NHS links in the header to see the same code render in each design system.' %>
 
-</br>
+<%= ds_heading "What's included" %>
+<%= ds_paragraph "You are previewing the #{t("design_system.#{brand}.name")} design system. It is built on these versions:" %>
 
-<div>
-  <p>This page got rendered <%= ds_timeago(Time.now, refresh_interval: 30000) %></p>
-</div>
+<%= ds_summary_list do |list|
+  list.add_row('GOV.UK Frontend', "v#{frontend_version('govuk')}")
+  list.add_row('NHS UK Frontend', "v#{frontend_version('nhsuk')}")
+  list.add_row('Design System gem', "v#{DesignSystem::VERSION}")
+end %>
+
+<%= ds_heading 'How this site is organised' %>
+<%= ds_paragraph 'Everything is grouped the same way the design systems group their own guidance, so you can find things the way you already think about them.' %>
+
+<%= ds_list(type: :bullet) do |list|
+  list.add_item { safe_join([ds_link_to('Styles', styles_path), ': the look every page shares, including layout and typography.']) }
+  list.add_item { safe_join([ds_link_to('Components', components_path), ': reusable interface pieces, grouped into form elements, content presentation and navigation.']) }
+  list.add_item { safe_join([ds_link_to('Utilities', utilities_path), ': JavaScript behaviours and helpers, such as Stimulus controllers and time ago.']) }
+end %>
+
+<%= ds_heading 'See it all together', level: 3 %>
+<%= ds_paragraph do %>
+  <%= ds_link_to 'Manage assistants', assistants_path %> is a complete worked example: a multi-field form with validation, built entirely from ds_ helpers.
+<% end %>
+
+<%= ds_heading 'How to use the examples' %>
+<%= ds_paragraph 'Open any page and each example shows the ERB you write, the rendered result, and the HTML it produces. Copy the ERB into your own views, and follow the documentation links through to the official GOV.UK and NHS guidance.' %>

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -40,6 +40,7 @@ end %>
 end %>
 
 <%= ds_heading 'See it all together', level: 3 %>
+<%= ds_inset_text 'This whole site is built with the gem. Every heading, form, table, link and footer you see is rendered by the same ds_ helpers you would use, in both brands.' %>
 <%= ds_paragraph do %>
   <%= ds_link_to 'Manage assistants', assistants_path %> is a complete worked example: a multi-field form with validation, built entirely from ds_ helpers.
 <% end %>

--- a/test/dummy/app/views/utilities/_sidebar.html.erb
+++ b/test/dummy/app/views/utilities/_sidebar.html.erb
@@ -1,0 +1,5 @@
+<%= ds_heading('JavaScript', level: 4) %>
+<ul class="<%= brand %>-list">
+  <li class="<%= brand %>-list__item"><%= ds_link_to('Stimulus controllers', utility_path('stimulus')) %></li>
+  <li class="<%= brand %>-list__item"><%= ds_link_to('Time ago', utility_path('timeago')) %></li>
+</ul>

--- a/test/dummy/app/views/utilities/index.html.erb
+++ b/test/dummy/app/views/utilities/index.html.erb
@@ -1,0 +1,13 @@
+<%=
+ds_fixed_elements do |ds|
+  ds.main_heading 'Utilities'
+
+  ds.breadcrumb('Home', root_path)
+
+  ds.lead_paragraph 'JavaScript behaviours and helpers that add interactivity to your pages, ready to use out of the box.'
+end
+%>
+
+<% content_for :sidebar do %>
+  <%= render partial: 'utilities/sidebar' %>
+<% end %>

--- a/test/dummy/app/views/utilities/stimulus.html.erb
+++ b/test/dummy/app/views/utilities/stimulus.html.erb
@@ -1,0 +1,19 @@
+<%=
+ds_fixed_elements do |ds|
+  ds.main_heading 'Stimulus controllers', caption: 'JavaScript'
+
+  ds.breadcrumb('Home', root_path)
+  ds.breadcrumb('Utilities', utilities_path)
+
+  ds.lead_paragraph 'The gem ships Stimulus controllers. Register them once in your importmap, then wire elements up with data-controller attributes.'
+end
+%>
+
+<%= component_preview :stimulus do %>
+<div data-controller="ds--hello-world">
+  <label for="hello-world-name">Name</label>
+  <input type="text" id="hello-world-name" data-ds--hello-world-target="name">
+  <%%= ds_button_tag('Greet', 'data-action': 'click->ds--hello-world#greet') %>
+  <p data-ds--hello-world-target="greeting"></p>
+</div>
+<% end %>

--- a/test/dummy/app/views/utilities/timeago.html.erb
+++ b/test/dummy/app/views/utilities/timeago.html.erb
@@ -1,0 +1,14 @@
+<%=
+ds_fixed_elements do |ds|
+  ds.main_heading 'Time ago', caption: 'JavaScript'
+
+  ds.breadcrumb('Home', root_path)
+  ds.breadcrumb('Utilities', utilities_path)
+
+  ds.lead_paragraph 'Use ds_timeago to show a timestamp as a relative time (for example "5 minutes ago") that updates itself in the browser.'
+end
+%>
+
+<%= component_preview :timeago do %>
+<%%= ds_timeago(Time.now, refresh_interval: 30000) %>
+<% end %>

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -205,6 +205,10 @@ en:
         paragraphs_lead:
           heading: Lead paragraph
           reference_url: https://service-manual.nhs.uk/design-system/styles/typography#lead-paragraph
+        stimulus:
+          heading: Stimulus controller
+        timeago:
+          heading: Time ago
     govuk:
       name: GOV.UK
       component_previews:
@@ -364,6 +368,10 @@ en:
         paragraphs_lead:
           heading: Lead paragraph
           reference_url: https://design-system.service.gov.uk/styles/paragraphs/#lead-paragraph
+        stimulus:
+          heading: Stimulus controller
+        timeago:
+          heading: Time ago
   helpers:
     fieldset:
       legend: Fieldset heading

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
                      constraints: { style: /[a-z0-9_-]+/ }
   resources :components, only: %i[index show], param: :component,
                          constraints: { component: /[a-z0-9_-]+/ }
+  resources :utilities, only: %i[index show], param: :utility,
+                        constraints: { utility: /[a-z0-9_-]+/ }
 
   resources :assistants
 end


### PR DESCRIPTION
## What?

Turns the dummy app home page into a clear "Get started" guide and adds a new **Utilities** section to the preview site.

The home page now welcomes developers, shows which GOV.UK and NHS UK Frontend versions the gem is built on, links to the gem, repository and changelog, and points to the site's three sections. The live JavaScript demos (Stimulus controllers and time ago) have moved off the home page into the new Utilities section.

## Why?

Our users are NHS and GOVUK developers who currently hand-build services in HTML and Bootstrap. The home page used to be a sandbox of loose demos, which did little to help a newcomer understand what the gem offers or how to find it.

The guide speaks to that audience and gets them productive by orienting them around the app itself, using the same Styles / Components / Utilities vocabulary the design systems already use. It also makes the bundled frontend versions and the key links (gem, repo, changelog) easy to find.

## How?

- Rewrote `pages/index.html.erb` as an orientation guide: lead intro, a "What's included" version summary, a "How this site is organised" map of the sections, and a "How to use the examples" note. All built from `ds_` helpers.
- Added a `frontend_version` helper that reads the bundled GOV.UK / NHS UK Frontend versions from the gem's stylesheet directory names, so they stay accurate when frontends are updated rather than being hard-coded.
- Added a `Utilities` section (`UtilitiesController`, route, index, sidebar) mirroring the existing Styles and Components sections, with the Stimulus controllers and time ago demos rendered through the standard `component_preview` (ERB input + rendered/HTML output).
- Added `Utilities` to the home page sidebar and locale entries for the new preview headings.
- Corrected the stale frontend versions in the README (5.9.0 → 5.11.1, 9.3.0 → 10.3.1) and updated the changelog.

## Testing?

- `bin/rails test` — 318 runs, 0 failures.
- `bin/rubocop` — no new offenses introduced by this change.
- Manually verified in the browser, both brands: home page, Utilities index, and both utility pages render; the Stimulus "Greet" demo and the time ago helper still work; no console errors.

## Screenshots?
<img width="3023" height="4013" alt="image" src="https://github.com/user-attachments/assets/62b9718e-a484-414e-8170-ac27aa47ba7b" />
