### PR TITLE
Update footer links and copyright notice in ApplicationController

### DIFF
--- a/app/controllers/concerns/design_system/branded.rb
+++ b/app/controllers/concerns/design_system/branded.rb
@@ -7,12 +7,29 @@ module DesignSystem
       attr_reader :navigation_items
       attr_reader :footer_links
       attr_accessor :copyright_notice
+      attr_writer :govuk_footer_crown, :govuk_footer_licence, :govuk_footer_copyright_logo
 
       helper DesignSystemHelper
     end
 
     def brand
       raise NotImplementedError, 'You need to implement #brand in your ApplicationController'
+    end
+
+    # Hide the GOV.UK footer's Crown emblem with `self.govuk_footer_crown = :hidden`.
+    def govuk_footer_crown_visible?
+      @govuk_footer_crown != :hidden
+    end
+
+    # Hide the GOV.UK footer's Open Government Licence with `self.govuk_footer_licence = :hidden`.
+    def govuk_footer_licence_visible?
+      @govuk_footer_licence != :hidden
+    end
+
+    # Hide the Royal Arms crest above the GOV.UK footer's copyright notice with
+    # `self.govuk_footer_copyright_logo = :hidden`.
+    def govuk_footer_copyright_logo_visible?
+      @govuk_footer_copyright_logo != :hidden
     end
 
     def add_navigation_item(label, path, options = {})

--- a/app/controllers/concerns/design_system/branded.rb
+++ b/app/controllers/concerns/design_system/branded.rb
@@ -7,7 +7,7 @@ module DesignSystem
       attr_reader :navigation_items
       attr_reader :footer_links
       attr_accessor :copyright_notice
-      attr_writer :govuk_footer_crown, :govuk_footer_licence, :govuk_footer_copyright_logo
+      attr_writer :govuk_footer_elements
 
       helper DesignSystemHelper
     end
@@ -16,20 +16,9 @@ module DesignSystem
       raise NotImplementedError, 'You need to implement #brand in your ApplicationController'
     end
 
-    # Hide the GOV.UK footer's Crown emblem with `self.govuk_footer_crown = :hidden`.
-    def govuk_footer_crown_visible?
-      @govuk_footer_crown != :hidden
-    end
-
-    # Hide the GOV.UK footer's Open Government Licence with `self.govuk_footer_licence = :hidden`.
-    def govuk_footer_licence_visible?
-      @govuk_footer_licence != :hidden
-    end
-
-    # Hide the Royal Arms crest above the GOV.UK footer's copyright notice with
-    # `self.govuk_footer_copyright_logo = :hidden`.
-    def govuk_footer_copyright_logo_visible?
-      @govuk_footer_copyright_logo != :hidden
+    # Hide the GOV.UK footer's Crown emblem, Open Government Licence and copyright logo if it is not yet a verified GOV.UK product
+    def govuk_footer_elements?
+      @govuk_footer_elements != :hidden
     end
 
     def add_navigation_item(label, path, options = {})

--- a/app/views/layouts/govuk/application.html.erb
+++ b/app/views/layouts/govuk/application.html.erb
@@ -130,7 +130,7 @@
   </div>
   <footer class="govuk-footer">
     <div class="govuk-width-container">
-      <% if controller.govuk_footer_crown_visible? %>
+      <% if controller.govuk_footer_elements? %>
       <svg
         focusable="false"
         role="presentation"
@@ -166,7 +166,7 @@
               <% end %>
             <% end %>
           </ul>
-          <% if controller.govuk_footer_licence_visible? %>
+          <% if controller.govuk_footer_elements? %>
           <svg
             aria-hidden="true"
             focusable="false"
@@ -187,13 +187,13 @@
               rel="license">Open Government Licence v3.0</a>, except where otherwise stated
           </span>
           <% end %>
-          <% if controller.copyright_notice.present? && !controller.govuk_footer_copyright_logo_visible? %>
+          <% if controller.copyright_notice.present? && !controller.govuk_footer_elements? %>
             <div class="govuk-footer__meta-custom">
               <%= controller.copyright_notice %>
             </div>
           <% end %>
         </div>
-        <% if controller.copyright_notice.present? && controller.govuk_footer_copyright_logo_visible? %>
+        <% if controller.copyright_notice.present? && controller.govuk_footer_elements? %>
           <div class="govuk-footer__meta-item">
             <span class="govuk-footer__link govuk-footer__copyright-logo">
               <%= controller.copyright_notice %>

--- a/app/views/layouts/govuk/application.html.erb
+++ b/app/views/layouts/govuk/application.html.erb
@@ -130,6 +130,7 @@
   </div>
   <footer class="govuk-footer">
     <div class="govuk-width-container">
+      <% if controller.govuk_footer_crown_visible? %>
       <svg
         focusable="false"
         role="presentation"
@@ -150,6 +151,7 @@
           <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z" />
         </g>
       </svg>
+      <% end %>
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <h2 class="govuk-visually-hidden">Support links</h2>
@@ -164,6 +166,7 @@
               <% end %>
             <% end %>
           </ul>
+          <% if controller.govuk_footer_licence_visible? %>
           <svg
             aria-hidden="true"
             focusable="false"
@@ -183,14 +186,20 @@
               href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
               rel="license">Open Government Licence v3.0</a>, except where otherwise stated
           </span>
+          <% end %>
+          <% if controller.copyright_notice.present? && !controller.govuk_footer_copyright_logo_visible? %>
+            <div class="govuk-footer__meta-custom">
+              <%= controller.copyright_notice %>
+            </div>
+          <% end %>
         </div>
-        <div class="govuk-footer__meta-item">
-          <% if controller.copyright_notice.present? %>
+        <% if controller.copyright_notice.present? && controller.govuk_footer_copyright_logo_visible? %>
+          <div class="govuk-footer__meta-item">
             <span class="govuk-footer__link govuk-footer__copyright-logo">
               <%= controller.copyright_notice %>
             </span>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </footer>

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -29,10 +29,13 @@ class ApplicationController < ActionController::Base
   end
 
   def set_footer_links
-    add_footer_link('Github', 'https://github.com/HealthDataInsight/design_system', target: '_blank', rel: 'noopener')
-    add_footer_link('Ruby Gem', 'https://rubygems.org/gems/design_system')
-    add_footer_link('Health Data Insight CIC', 'https://healthdatainsight.org.uk/')
-    self.copyright_notice = 'Design System © 2026 Health Data Insight CIC'
+    self.govuk_footer_crown = :hidden
+    self.govuk_footer_licence = :hidden
+    self.govuk_footer_copyright_logo = :hidden
+    add_footer_link('Download the RubyGem', 'https://rubygems.org/gems/design_system', target: '_blank', rel: 'noopener')
+    add_footer_link('View the source on GitHub', 'https://github.com/HealthDataInsight/design_system', target: '_blank', rel: 'noopener')
+    add_footer_link('Get in touch', 'https://github.com/HealthDataInsight/design_system/issues', target: '_blank', rel: 'noopener')
+    self.copyright_notice = '© Health Data Insight CIC 2026'
   end
 
   def searchbar_url

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -29,9 +29,10 @@ class ApplicationController < ActionController::Base
   end
 
   def set_footer_links
-    add_footer_link('Custom Link', '#', target: '_blank', rel: 'noopener')
-    add_footer_link('Another Link', '#')
-    self.copyright_notice = '© NHS England 2025'
+    add_footer_link('Github', 'https://github.com/HealthDataInsight/design_system', target: '_blank', rel: 'noopener')
+    add_footer_link('Ruby Gem', 'https://rubygems.org/gems/design_system')
+    add_footer_link('Health Data Insight CIC', 'https://healthdatainsight.org.uk/')
+    self.copyright_notice = 'Design System © 2026 Health Data Insight CIC'
   end
 
   def searchbar_url

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -29,9 +29,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_footer_links
-    self.govuk_footer_crown = :hidden
-    self.govuk_footer_licence = :hidden
-    self.govuk_footer_copyright_logo = :hidden
+    self.govuk_footer_elements = :hidden
     add_footer_link('Download the RubyGem', 'https://rubygems.org/gems/design_system', target: '_blank', rel: 'noopener')
     add_footer_link('View the source on GitHub', 'https://github.com/HealthDataInsight/design_system', target: '_blank', rel: 'noopener')
     add_footer_link('Get in touch', 'https://github.com/HealthDataInsight/design_system/issues', target: '_blank', rel: 'noopener')

--- a/test/dummy/cypress/e2e/footer_links.cy.js
+++ b/test/dummy/cypress/e2e/footer_links.cy.js
@@ -2,12 +2,31 @@ describe('Footer links', () => {
   it('renders custom footer links with options', () => {
     cy.visit('/');
     cy.get('footer.nhsuk-footer ul.nhsuk-footer__list')
-      .contains('a.nhsuk-footer__list-item-link', 'Custom Link')
-      .should('have.attr', 'href', '#');
+      .contains('a.nhsuk-footer__list-item-link', 'Download the RubyGem')
+      .should('have.attr', 'href', 'https://rubygems.org/gems/design_system');
     cy.get('footer.nhsuk-footer ul.nhsuk-footer__list a.nhsuk-footer__list-item-link[target="_blank"]').should('exist');
     cy.get('footer.nhsuk-footer ul.nhsuk-footer__list a.nhsuk-footer__list-item-link[rel="noopener"]').should('exist');
     cy.get('footer.nhsuk-footer ul.nhsuk-footer__list')
-      .contains('a.nhsuk-footer__list-item-link', 'Another Link')
-      .should('have.attr', 'href', '#');
+      .contains('a.nhsuk-footer__list-item-link', 'View the source on GitHub')
+      .should('have.attr', 'href', 'https://github.com/HealthDataInsight/design_system');
+    cy.get('footer.nhsuk-footer ul.nhsuk-footer__list')
+      .contains('a.nhsuk-footer__list-item-link', 'Get in touch')
+      .should('have.attr', 'href', 'https://github.com/HealthDataInsight/design_system/issues');
+  });
+
+  it('renders the copyright notice', () => {
+    cy.visit('/');
+    cy.get('footer.nhsuk-footer .nhsuk-footer__meta p')
+      .should('contain.text', '© Health Data Insight CIC 2026');
+  });
+
+  it('hides the Crown emblem, OGL licence and copyright crest on the GOV.UK footer', () => {
+    cy.visit('/?brand=govuk');
+    cy.get('footer.govuk-footer').should('exist');
+    cy.get('footer.govuk-footer .govuk-footer__crown').should('not.exist');
+    cy.get('footer.govuk-footer .govuk-footer__licence-logo').should('not.exist');
+    cy.get('footer.govuk-footer .govuk-footer__copyright-logo').should('not.exist');
+    cy.get('footer.govuk-footer .govuk-footer__meta-custom')
+      .should('contain.text', '© Health Data Insight CIC 2026');
   });
 });


### PR DESCRIPTION
## What?

Remove NHS England copyright from the dummy app

## Why?

It's not their copyright

## How?

Replace NHSE footer links and copyright with HDI ones

## Testing?

Eyeballed in the browser

## Screenshots (optional)

NHS:
<img width="1351" height="196" alt="image" src="https://github.com/user-attachments/assets/e28d19e1-6216-4dd6-bdb1-dba41c652b9a" />

GOV:
<img width="1110" height="176" alt="image" src="https://github.com/user-attachments/assets/c156d113-2ba0-4e66-aace-51f9cf348e46" />

## Anything Else?

No