### PR TITLE
Disable assistants for production

### DIFF
--- a/test/controllers/assistants_controller_test.rb
+++ b/test/controllers/assistants_controller_test.rb
@@ -64,4 +64,10 @@ class AssistantsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to assistants_url
   end
+
+  test 'returns not found when assistant demo is disabled' do
+    ApplicationController.any_instance.stubs(:assistant_demo_enabled?).returns(false)
+    get assistants_url
+    assert_response :not_found
+  end
 end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -7,12 +7,18 @@ class ApplicationController < ActionController::Base
   include DesignSystem::Branded
 
   before_action :add_navigation, :set_service_name, :set_footer_links, :searchbar_url
-  helper_method :brand
+  helper_method :brand, :assistant_demo_enabled?
 
   private
 
+  def assistant_demo_enabled?
+    !Rails.env.production?
+  end
+
   def add_navigation
-    add_navigation_item('Manage Assistants', assistants_path, icon: 'users')
+    if assistant_demo_enabled?
+      add_navigation_item('Manage Assistants', assistants_path, icon: 'users')
+    end
 
     add_navigation_item('GOV.UK', url_for(brand: 'govuk'), icon: 'ellipsis-horizontal-circle')
     add_navigation_item('NHS', url_for(brand: 'nhsuk'), icon: 'ellipsis-horizontal-circle')

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -16,9 +16,7 @@ class ApplicationController < ActionController::Base
   end
 
   def add_navigation
-    if assistant_demo_enabled?
-      add_navigation_item('Manage Assistants', assistants_path, icon: 'users')
-    end
+    add_navigation_item('Manage Assistants', assistants_path, icon: 'users') if assistant_demo_enabled?
 
     add_navigation_item('GOV.UK', url_for(brand: 'govuk'), icon: 'ellipsis-horizontal-circle')
     add_navigation_item('NHS', url_for(brand: 'nhsuk'), icon: 'ellipsis-horizontal-circle')

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   private
 
   def assistant_demo_enabled?
-    !Rails.env.production?
+    Rails.application.routes.named_routes.key?(:assistants)
   end
 
   def add_navigation

--- a/test/dummy/app/controllers/assistants_controller.rb
+++ b/test/dummy/app/controllers/assistants_controller.rb
@@ -1,4 +1,5 @@
 class AssistantsController < ApplicationController
+  before_action :ensure_assistant_demo_enabled!
   before_action :set_assistant, only: %i[show edit update destroy]
   before_action :all_departments, only: %i[new edit create update]
 
@@ -45,6 +46,12 @@ class AssistantsController < ApplicationController
   end
 
   private
+
+  def ensure_assistant_demo_enabled!
+    return if assistant_demo_enabled?
+
+    raise ActionController::RoutingError, 'Not Found'
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_assistant

--- a/test/dummy/app/views/pages/index.html.erb
+++ b/test/dummy/app/views/pages/index.html.erb
@@ -41,8 +41,10 @@ end %>
 
 <%= ds_heading 'See it all together', level: 3 %>
 <%= ds_inset_text 'This whole site is built with the gem. Every heading, form, table, link and footer you see is rendered by the same ds_ helpers you would use, in both brands.' %>
-<%= ds_paragraph do %>
-  <%= ds_link_to 'Manage assistants', assistants_path %> is a complete worked example: a multi-field form with validation, built entirely from ds_ helpers.
+<% if assistant_demo_enabled? %>
+  <%= ds_paragraph do %>
+    <%= ds_link_to 'Manage assistants', assistants_path %> is a complete worked example: a multi-field form with validation, built entirely from ds_ helpers.
+  <% end %>
 <% end %>
 
 <%= ds_heading 'How to use the examples' %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -16,5 +16,5 @@ Rails.application.routes.draw do
   resources :utilities, only: %i[index show], param: :utility,
                         constraints: { utility: /[a-z0-9_-]+/ }
 
-  resources :assistants
+  resources :assistants unless Rails.env.production?
 end


### PR DESCRIPTION
## What?

Disable the Manage Assistants demo in production on the dummy docs app.

## Why?

It is a local demo only; production should not expose database CRUD or invite unwanted traffic.

## How?

Hide nav and homepage links when `Rails.env.production?`, skip assistant routes in production, and return 404 from `AssistantsController` as a fallback.

## Testing?

Integration test stubs `assistant_demo_enabled?` as false and expects 404 on `GET /assistants`.
Also tested by Conductor agent

## Screenshots (optional)

<img width="1280" height="240" alt="image" src="https://github.com/user-attachments/assets/54b58d10-b1e6-4778-94a2-1d466de17d2d" />

## Anything Else?

Pagination component demos still use in-memory data and are unaffected.