### PR TITLE
Temp fix to display stacked radio options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated `ds_panel`, `ds_callout`, `ds_details`, `ds_heading`, `ds_action_link`, `ds_start_button`, and `ds_list` from PORO builders to ViewComponents (no API change).
 
+### Fixed
+
+- Fixed radio fieldset preview components to correctly display multiple options.
+
 ## [0.14.0] - 2026-05-01
 
 ### Fixed

--- a/test/dummy/app/views/components/radios.html.erb
+++ b/test/dummy/app/views/components/radios.html.erb
@@ -18,8 +18,8 @@ end %>
 <%= component_preview :radios_fieldset, fragment: :form_group do %>
 <%%= ds_form_with(model: Assistant.new) do |f|
   f.ds_radio_buttons_fieldset :lunch_option, hint: "Demo for ds_radio_buttons_fieldset" do
-    f.ds_radio_button :lunch_option, "Salad", link_errors: true
-    f.ds_radio_button :lunch_option, "Jacket potato"
+    f.ds_radio_button(:lunch_option, "Salad", link_errors: true) +
+    f.ds_radio_button(:lunch_option, "Jacket potato")
   end
 end %>
 <% end %>


### PR DESCRIPTION
## What?

Fixes the `radios_fieldset` preview in the dummy app so both radio options render. Previously only the last option ("Jacket potato") showed and "Salad" silently disappeared, making a correctly-working component look broken.

## Why?

The preview is meant to demonstrate a stacked radio-buttons fieldset with multiple options. Rendering only one option is misleading to anyone using the dummy as a reference for `ds_radio_buttons_fieldset`.

## How?

`ds_radio_buttons_fieldset` renders whatever its block returns, and a Ruby block returns only its last expression — so with the two `ds_radio_button` calls on separate lines, only the last one was returned and rendered. Concatenating them with `+` makes the block return both radio buttons' output.

```erb
f.ds_radio_button(:lunch_option, "Salad", link_errors: true) +
f.ds_radio_button(:lunch_option, "Jacket potato")
```

## Testing?

Rendered the `radios_fieldset` preview locally — both "Salad" and "Jacket potato" now appear in the fieldset.

## Screenshots (optional)

N/A

## Anything Else?

This is a stopgap at the preview level (hence "temp fix"). The cleaner solution is for `ds_radio_buttons_fieldset` to capture its block's output (like `capture`) rather than rely on the return value, so consumers can list `ds_radio_button` calls line by line without manually joining them with `+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)